### PR TITLE
Add `<rootDir>` to Jest ignore paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,9 +102,9 @@
       "\\.(css|scss)$": "identity-obj-proxy"
     },
     "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dev/",
-      "/dist/"
+      "<rootDir>/node_modules/",
+      "<rootDir>/dev/",
+      "<rootDir>/dist/"
     ],
     "testMatch": [
       "**/__tests__/**.test.js?(x)"


### PR DESCRIPTION
The use case here is that if — like me — you keep code in a directory
like `~/dev/pure-react-carousel/`, tests were not being run.

See [Jest documentation](https://facebook.github.io/jest/docs/en/configuration.html#testpathignorepatterns-array-string) for details on `rootDir`.