### PR TITLE
Fix isNewCurrentSlide logic to prevent updating accidentally (fixes #76)

### DIFF
--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -86,6 +86,7 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     const newStoreState = {};
 
     [
+      'currentSlide',
       'disableAnimation',
       'hasMasterSpinner',
       'interval',
@@ -107,12 +108,13 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     });
 
     const { currentSlide, disableAnimation } = this.carouselStore.getStoreState();
-    const isNewCurrentSlide = currentSlide !== nextProps.currentSlide;
-    const isAnimationDisabled = newStoreState.disableAnimation || disableAnimation;
 
-    if (isNewCurrentSlide) {
-      newStoreState.currentSlide = nextProps.currentSlide;
-    }
+    const isNewCurrentSlide = (
+      Object.prototype.hasOwnProperty.call(newStoreState, 'currentSlide') &&
+      currentSlide !== nextProps.currentSlide
+    );
+
+    const isAnimationDisabled = newStoreState.disableAnimation || disableAnimation;
 
     if (isNewCurrentSlide && !isAnimationDisabled) {
       newStoreState.disableAnimation = true;

--- a/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
+++ b/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
@@ -62,6 +62,16 @@ describe('<CarouselProvider />', () => {
     const end = clone(instance.carouselStore.state);
     expect(start).toEqual(end);
   });
+  it('should not reset the currentSlide or disableAnimation values when unrelated props change', () => {
+    const wrapper = shallow(<CarouselProvider {...props} data-foo={1} />);
+    const instance = wrapper.instance();
+    instance.carouselStore.setStoreState({ currentSlide: 2 });
+    const start = clone(instance.carouselStore.state);
+    wrapper.setProps({ naturalSlideWidth: 300 });
+    const end = clone(instance.carouselStore.state);
+    expect(start.currentSlide).toEqual(end.currentSlide);
+    expect(start.disableAnimation).toEqual(end.disableAnimation);
+  });
   it('should set disable animation to false if we updated currentSlide and animationDisabled is false', () => {
     const wrapper = mount((
       <CarouselProvider


### PR DESCRIPTION
Ref: https://github.com/express-labs/pure-react-carousel/issues/76

Previously, `isNewCurrentSlide` was true whenever *any* props changed,
if there was no previous `currentSlide` prop.

With this change, we only consider it a "new" current slide if:

- There was a `currentSlide` prop provided
- The `currentSlide` prop value is different than the actual current slide

I believe the tests cover the important cases here, but open to feedback!