### PR TITLE
Simple .sliderAnimation performance improvement

### DIFF
--- a/src/Slider/slider.css
+++ b/src/Slider/slider.css
@@ -35,6 +35,7 @@
 .sliderAnimation {
   transition: transform 500ms;
   transition-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1.000); /* easeInOutCubic */
+  will-change: transform;
 }
 
 .masterSpinnerContainer {


### PR DESCRIPTION
Hello,
I am playing around with the Carousel.

I've noticed that the default slide animation `.sliderAnimation` doesn't have the `will-change` CSS property which makes the animation a little bit more performant by reducing the browser repaints.

This is a simple Pull Request, I have not cloned nor ran any tests after this edit.