### PR TITLE
Typo fix in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ More pseudocode.
 
 ```javascript
   import React from 'react';
-  import { WithProvider } from 'pure-react-carousel';
+  import { WithStore } from 'pure-react-carousel';
 
   class YourComponentHere extends React.Component {
     // ... stuff


### PR DESCRIPTION
I'm guessing this is wrong since there are no other mentions of `withProvider`.