### PR TITLE
changed keyof T to satisfy TypeScript 9

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -86,7 +86,7 @@ export interface CarouselInjectedProps {
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
 type Diff<T extends string, U extends string> = ({ [P in T]: P } &
   { [P in U]: never } & { readonly [x: string]: never })[T]
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+type Omit<T, K extends keyof T> = Pick<T, Diff<Extract<keyof T, string>, Extract<K, string>>>
 
 type MapStateToProps<TStateProps> = (state: CarouselState) => TStateProps
 


### PR DESCRIPTION
TypeScript 2.9 has a breaking change where now, an object of a generic type T must be Extract<keyof T, string>

```
ERROR in [at-loader] ./node_modules/pure-react-carousel/typings/index.d.ts:89:48 
    TS2344: Type 'keyof T' does not satisfy the constraint 'string'.
  Type 'string | number | symbol' is not assignable to type 'string'.
    Type 'number' is not assignable to type 'string'.
```