### PR TITLE
Add disableKeyboard option to disable changing slides on left/right a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Following the documentation above, only props save to use are exposed:
 interface CarouselState {
   readonly currentSlide: number
   readonly disableAnimation: boolean
+  readonly disableKeyboard: boolean
   readonly hasMasterSpinner: boolean
   readonly imageErrorCount: number
   readonly imageSuccessCount: number

--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -10,6 +10,7 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     className: PropTypes.string,
     currentSlide: PropTypes.number,
     disableAnimation: PropTypes.bool,
+    disableKeyboard: PropTypes.bool,
     hasMasterSpinner: PropTypes.bool,
     interval: PropTypes.number,
     isPageScrollLocked: PropTypes.bool,
@@ -27,10 +28,15 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     visibleSlides: PropTypes.number,
   }
 
+  static childContextTypes = {
+    carouselStore: PropTypes.object,
+  }
+
   static defaultProps = {
     className: null,
     currentSlide: 0,
     disableAnimation: false,
+    disableKeyboard: false,
     hasMasterSpinner: false,
     interval: 5000,
     isPageScrollLocked: false,
@@ -45,15 +51,12 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     visibleSlides: 1,
   }
 
-  static childContextTypes = {
-    carouselStore: PropTypes.object,
-  }
-
   constructor(props, context) {
     super(props, context);
     const options = {
       currentSlide: props.currentSlide,
       disableAnimation: props.disableAnimation,
+      disableKeyboard: props.disableKeyboard,
       hasMasterSpinner: props.hasMasterSpinner,
       imageErrorCount: 0,
       imageSuccessCount: 0,
@@ -88,6 +91,7 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     [
       'currentSlide',
       'disableAnimation',
+      'disableKeyboard',
       'hasMasterSpinner',
       'interval',
       'isPlaying',

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -15,6 +15,7 @@ const Slider = class Slider extends React.Component {
     classNameTrayWrap: PropTypes.string,
     currentSlide: PropTypes.number.isRequired,
     disableAnimation: PropTypes.bool.isRequired,
+    disableKeyboard: PropTypes.bool.isRequired,
     dragEnabled: PropTypes.bool.isRequired,
     hasMasterSpinner: PropTypes.bool.isRequired,
     interval: PropTypes.number.isRequired,
@@ -44,6 +45,7 @@ const Slider = class Slider extends React.Component {
     classNameTray: null,
     classNameTrayWrap: null,
     disableAnimation: false,
+    disableKeyboard: false,
     height: null,
     onMasterSpinner: null,
     style: {},
@@ -245,10 +247,10 @@ const Slider = class Slider extends React.Component {
 
   handleOnKeyDown(ev) {
     const { keyCode } = ev;
-    const { carouselStore, currentSlide, totalSlides, visibleSlides } = this.props;
+    const { carouselStore, currentSlide, disableKeyboard, totalSlides, visibleSlides } = this.props;
     const newStoreState = {};
 
-    if (totalSlides <= visibleSlides) return;
+    if ((disableKeyboard === true) || (totalSlides <= visibleSlides)) return;
 
     // left arrow
     if (keyCode === 37) {
@@ -406,6 +408,7 @@ const Slider = class Slider extends React.Component {
       classNameTrayWrap,
       currentSlide,
       disableAnimation,
+      disableKeyboard,
       dragEnabled,
       hasMasterSpinner,
       interval,

--- a/src/Slider/__tests__/Slider.test.jsx
+++ b/src/Slider/__tests__/Slider.test.jsx
@@ -373,6 +373,28 @@ describe('<Slider />', () => {
     expect(wrapper.prop('carouselStore').state.currentSlide).toBe(3);
   });
 
+  it('should not move the slider from 0 to 1 if right arrow is pressed and keyboard is disabled', () => {
+    const carouselStore = new Store({
+      currentSlide: 0,
+      disableKeyboard: true,
+    });
+    const wrapper = mount(<Slider {...props} currentSlide={0} disableKeyboard carouselStore={carouselStore} />);
+    expect(wrapper.prop('carouselStore').state.currentSlide).toBe(0);
+    wrapper.find('.carousel__slider').simulate('keydown', { keyCode: 39 });
+    expect(wrapper.prop('carouselStore').state.currentSlide).toBe(0);
+  });
+
+  it('should not move the slider from 1 to 0 if left arrow is pressed and keyboard is disabled', () => {
+    const carouselStore = new Store({
+      currentSlide: 1,
+      disableKeyboard: true,
+    });
+    const wrapper = mount(<Slider {...props} currentSlide={1} disableKeyboard carouselStore={carouselStore} />);
+    expect(wrapper.prop('carouselStore').state.currentSlide).toBe(1);
+    wrapper.find('.carousel__slider').simulate('keydown', { keyCode: 37 });
+    expect(wrapper.prop('carouselStore').state.currentSlide).toBe(1);
+  });
+
   it('the .carousel__slider should have a default tabIndex of 0', () => {
     const wrapper = shallow(<Slider {...props} />);
     expect(wrapper.find('.carousel__slider').prop('tabIndex')).toBe(0);

--- a/src/Slider/index.js
+++ b/src/Slider/index.js
@@ -4,6 +4,7 @@ import WithStore from '../Store/WithStore';
 export default WithStore(Slider, state => ({
   currentSlide: state.currentSlide,
   disableAnimation: state.disableAnimation,
+  disableKeyboard: state.disableKeyboard,
   dragEnabled: state.dragEnabled,
   hasMasterSpinner: state.hasMasterSpinner,
   interval: state.interval,

--- a/src/helpers/component-config.js
+++ b/src/helpers/component-config.js
@@ -147,6 +147,7 @@ export default {
       children: 'hello',
       currentSlide: 0,
       disableAnimation: false,
+      disableKeyboard: false,
       dragEnabled: true,
       hasMasterSpinner: false,
       interval: 5000,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,6 +20,7 @@ import {
 interface CarouselState {
   readonly currentSlide: number
   readonly disableAnimation: boolean
+  readonly disableKeyboard: boolean
   readonly hasMasterSpinner: boolean
   readonly imageErrorCount: number
   readonly imageSuccessCount: number
@@ -43,6 +44,7 @@ interface CarouselProviderProps {
   readonly className?: string
   readonly currentSlide?: CarouselState['currentSlide']
   readonly disableAnimation?: CarouselState['disableAnimation']
+  readonly disableKeyboard?: CarouselState['disableKeyboard']
   readonly hasMasterSpinner?: CarouselState['hasMasterSpinner']
   readonly interval?: number
   readonly isPlaying?: boolean


### PR DESCRIPTION
When slides contain input elements (text or number) moving in the inputs with left or right arrows makes the slides move.

Added a disableKeyboard optional flag to prevent this.