### PR TITLE
Slide element accessibility improvement

### DIFF
--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -146,6 +146,7 @@ const Slide = class Slide extends React.PureComponent {
         ref={(el) => { this.tagRef = el; }}
         tabIndex={newTabIndex}
         aria-hidden={!this.isVisible()}
+        role="option"
         onFocus={this.handleOnFocus}
         onBlur={this.handleOnBlur}
         className={newClassName}

--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -145,7 +145,7 @@ const Slide = class Slide extends React.PureComponent {
       <Tag
         ref={(el) => { this.tagRef = el; }}
         tabIndex={newTabIndex}
-        aria-hidden={!this.isVisible()}
+        aria-selected={this.isVisible()}
         role="option"
         onFocus={this.handleOnFocus}
         onBlur={this.handleOnBlur}


### PR DESCRIPTION
Adds missing `role="option"` and changes `aria-hidden` to `aria-selected`.

Resources:
- https://stackoverflow.com/questions/39523226/what-is-role-listbox-used-when-creating-carousel
- https://stackoverflow.com/questions/16840054/wai-aria-roles-for-carousels-a-k-a-sliders-slideshows-galleries
- https://jongund.github.io/aria-examples/bootstrap-carousel/