### PR TITLE
Fix: Remove `step` attribute from Slider div

### DIFF
--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -544,6 +544,9 @@ const Slider = class Slider extends React.Component {
 
     // console.log(Object.assign({}, trayStyle), new Date());
 
+    // remove `step` from Slider div, since it isn't a valid html attribute
+    const { step, ...rest } = props;
+
     return (
       <div
         ref={(el) => { this.sliderElement = el; }}
@@ -553,7 +556,7 @@ const Slider = class Slider extends React.Component {
         tabIndex={newTabIndex}
         onKeyDown={this.handleOnKeyDown}
         role="listbox"
-        {...props}
+        {...rest}
       >
         <div className={trayWrapClasses} style={trayWrapStyle}>
           <TrayTag


### PR DESCRIPTION
When I test my website through [w3 validator](https://validator.w3.org/) I get an error on the Slider component's `<div>`, saying that _`step` is not allowed on element `div`_

This PR simply prevent `step` prop to be assigned to the HTML element.

![screenshot 2019-01-17 at 13 54 42](https://user-images.githubusercontent.com/8927326/51323231-79408e80-1a5f-11e9-9854-6603474349a1.png)
