### PR TITLE
Add two props to DotGroup

### DIFF
--- a/src/DotGroup/DotGroup.jsx
+++ b/src/DotGroup/DotGroup.jsx
@@ -13,32 +13,51 @@ const DotGroup = class DotGroup extends React.Component {
     totalSlides: PropTypes.number.isRequired,
     visibleSlides: PropTypes.number.isRequired,
     dotNumbers: PropTypes.bool,
+    disableActiveDots: PropTypes.bool,
+    showAsSelectedForCurrentSlideOnly: PropTypes.bool,
   }
 
   static defaultProps = {
     children: null,
     className: null,
     dotNumbers: false,
+    disableActiveDots: true,
+    showAsSelectedForCurrentSlideOnly: false
   }
 
   renderDots() {
-    const { currentSlide, totalSlides, visibleSlides } = this.props;
+    const {
+      currentSlide,
+      totalSlides,
+      visibleSlides,
+      disableActiveDots,
+      showAsSelectedForCurrentSlideOnly,
+    } = this.props;
     const dots = [];
     for (let i = 0; i < totalSlides; i += 1) {
-      const selected = i >= currentSlide && i < (currentSlide + visibleSlides);
+      const multipleSelected = i >= currentSlide && i < (currentSlide + visibleSlides);
+      const singleSelected = i === currentSlide;
+      const selected = showAsSelectedForCurrentSlideOnly ? singleSelected : multipleSelected;
       const slide = i >= totalSlides - visibleSlides ? totalSlides - visibleSlides : i;
       dots.push(
-        <Dot key={i} slide={slide} selected={selected} disabled={selected}>
+        <Dot key={i} slide={slide} selected={selected} disabled={disableActiveDots ? selected : false}>
           <span className={cn['carousel__dot-group-dot']}>{this.props.dotNumbers && i + 1}</span>
         </Dot>,
       );
     }
     return dots;
-  }
 
   render() {
     const {
-      carouselStore, children, className, currentSlide, dotNumbers, totalSlides, visibleSlides,
+      carouselStore, 
+      children, 
+      className, 
+      currentSlide, 
+      dotNumbers, 
+      totalSlides, 
+      visibleSlides, 
+      disableActiveDots,
+      showAsSelectedForCurrentSlideOnly,
       ...props
     } = this.props;
 

--- a/src/DotGroup/DotGroup.jsx
+++ b/src/DotGroup/DotGroup.jsx
@@ -22,7 +22,7 @@ const DotGroup = class DotGroup extends React.Component {
     className: null,
     dotNumbers: false,
     disableActiveDots: true,
-    showAsSelectedForCurrentSlideOnly: false
+    showAsSelectedForCurrentSlideOnly: false,
   }
 
   renderDots() {
@@ -40,22 +40,28 @@ const DotGroup = class DotGroup extends React.Component {
       const selected = showAsSelectedForCurrentSlideOnly ? singleSelected : multipleSelected;
       const slide = i >= totalSlides - visibleSlides ? totalSlides - visibleSlides : i;
       dots.push(
-        <Dot key={i} slide={slide} selected={selected} disabled={disableActiveDots ? selected : false}>
+        <Dot
+          key={i}
+          slide={slide}
+          selected={selected}
+          disabled={disableActiveDots ? selected : false}
+        >
           <span className={cn['carousel__dot-group-dot']}>{this.props.dotNumbers && i + 1}</span>
         </Dot>,
       );
     }
     return dots;
+  }
 
   render() {
     const {
-      carouselStore, 
-      children, 
-      className, 
-      currentSlide, 
-      dotNumbers, 
-      totalSlides, 
-      visibleSlides, 
+      carouselStore,
+      children,
+      className,
+      currentSlide,
+      dotNumbers,
+      totalSlides,
+      visibleSlides,
       disableActiveDots,
       showAsSelectedForCurrentSlideOnly,
       ...props


### PR DESCRIPTION
### disableActiveDots
#### Current behaviour
When a dot is shown as selected, it is disabled. So when two slides are visibles, one is fully visible and the other one is partially visible, we can't click on the dot corresponding to the partially visible slide. 
#### Improved behaviour
This new prop does not change the default behaviour (so no breaking change), but it adds the option to let the dots enabled whatever, even if the slide is already visible.

### showAsSelectedForCurrentSlideOnly
#### Current behaviour
For now, the dots are shown as selected is the slide is visible, so there might be several dots shown as selected. We can also want to show the dot as selected for the current slide only.
#### Improved behaviour
This new prop does not change the default behaviour (so no breaking change), but it adds the option to show the dot as selected for the current slide only.