### PR TITLE
allow renderDots() in DotGroup to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ A compound component that creates a bunch of Dot's automatically for you.
 | dotNumbers | boolean | false | No | Setting to true automatically adds text numbers the dot buttons starting at 1. |
 | disableActiveDots | boolean | true | No | Setting to true make all dots, including active dots, enabled. |
 | showAsSelectedForCurrentSlideOnly | boolean | false | No | Setting to true show only the current slide dot as selected. |
+| renderDots | function| null | No | It accpets `props` and overrides renderDots() in <DotGroup/>. |
 
 #### The DotGroup component creates the following pseudo HTML by default:
 

--- a/src/DotGroup/DotGroup.jsx
+++ b/src/DotGroup/DotGroup.jsx
@@ -15,6 +15,7 @@ const DotGroup = class DotGroup extends React.Component {
     dotNumbers: PropTypes.bool,
     disableActiveDots: PropTypes.bool,
     showAsSelectedForCurrentSlideOnly: PropTypes.bool,
+    renderDots: PropTypes.func,
   }
 
   static defaultProps = {
@@ -23,6 +24,7 @@ const DotGroup = class DotGroup extends React.Component {
     dotNumbers: false,
     disableActiveDots: true,
     showAsSelectedForCurrentSlideOnly: false,
+    renderDots: null,
   }
 
   renderDots() {
@@ -32,7 +34,13 @@ const DotGroup = class DotGroup extends React.Component {
       visibleSlides,
       disableActiveDots,
       showAsSelectedForCurrentSlideOnly,
+      renderDots,
     } = this.props;
+
+    if (renderDots) {
+      return renderDots(this.props);
+    }
+
     const dots = [];
     for (let i = 0; i < totalSlides; i += 1) {
       const multipleSelected = i >= currentSlide && i < (currentSlide + visibleSlides);
@@ -64,6 +72,7 @@ const DotGroup = class DotGroup extends React.Component {
       visibleSlides,
       disableActiveDots,
       showAsSelectedForCurrentSlideOnly,
+      renderDots,
       ...props
     } = this.props;
 

--- a/src/DotGroup/__tests__/DotGroup.test.jsx
+++ b/src/DotGroup/__tests__/DotGroup.test.jsx
@@ -4,6 +4,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import clone from 'clone';
 import components from '../../helpers/component-config';
 import DotGroup from '../DotGroup';
+import Dot from '../../Dot';
 
 configure({ adapter: new Adapter() });
 
@@ -57,5 +58,25 @@ describe('<DotGroup />', () => {
     expect(wrapper.children().at(0).prop('selected')).toEqual(false);
     expect(wrapper.children().at(1).prop('selected')).toEqual(true);
     expect(wrapper.children().at(2).prop('selected')).toEqual(true);
+  });
+  it('should render dots differently if renderDots is provided', () => {
+    const renderDots = (props) => {
+      const {
+        totalSlides,
+      } = props;
+      const dots = [];
+
+      for (let i = 0; i < totalSlides; i += 1) {
+        dots.push(
+          <img key={i} src="data:," alt />
+        );
+      }
+      return dots;
+    };
+
+    const wrapper = shallow(<DotGroup {...props} renderDots={renderDots} />);
+    expect(wrapper.find('img').at(0).text()).toEqual('');
+    expect(wrapper.find('img').at(1).text()).toEqual('');
+    expect(wrapper.find('img').at(2).text()).toEqual('');
   });
 });


### PR DESCRIPTION
This PR allow <DotGroup /> to accept a prop `renderDots()` in order to override the default rendering
```
<DotGroup 
  renderDots={(props) => {
    // return JSX
  })
/>
```