### PR TITLE
fix(Slider): check if a touch exists before firing a fake drag

### DIFF
--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -327,8 +327,13 @@ const Slider = class Slider extends React.Component {
     window.cancelAnimationFrame.call(window, this.moveTimer);
 
     const touch = ev.targetTouches[0];
-    this.fakeOnDragMove(touch.screenX, touch.screenY);
-    this.callCallback('onTouchMove', ev);
+    // TODO: This prevents an error case we were seeing internally, but long term we
+    //  should evaluate if there's something better we can do to ensure there's not
+    //  a different problem that we can address instead.
+    if (touch) {
+      this.fakeOnDragMove(touch.screenX, touch.screenY);
+      this.callCallback('onTouchMove', ev);
+    }
   }
 
   forward() {

--- a/src/Slider/__tests__/Slider.test.jsx
+++ b/src/Slider/__tests__/Slider.test.jsx
@@ -463,6 +463,21 @@ describe('<Slider />', () => {
       expect(wrapper.state('deltaY')).toBe(100);
     });
 
+    it('should handle not being given a touch event', () => {
+      const wrapper = shallow(<Slider {...props} />);
+      const noTouches = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        targetTouches: [],
+      };
+
+      expect(wrapper.state('startX')).toBe(0);
+      expect(wrapper.state('startY')).toBe(0);
+      wrapper.find('.sliderTray').simulate('touchmove', noTouches);
+      expect(wrapper.state('deltaX')).toBe(0);
+      expect(wrapper.state('deltaY')).toBe(0);
+    });
+
     it('touchmove should not alter state if touchEnabled is false', () => {
       const wrapper = shallow(<Slider {...props} touchEnabled={false} />);
       expect(wrapper.state('startX')).toBe(0);


### PR DESCRIPTION
**What**:

Check that a touch is available before access properties on it to fire a `fakeOnDragMove`

**Why**:

We were seeing high rates of errors internally at Express in our bug tracking tools.

**How**:

Simple if check, and tests that validate it works 💯

**Checklist**:

- [x] Documentation added/updated (N/A)
- [x] Typescript definitions updated (N/A)
- [x] Tests added and passing
- [x] Ready to be merged
