### PR TITLE
Allow using DotGroup prop renderDots in Typescript

### DIFF
--- a/src/DotGroup/DotGroup.jsx
+++ b/src/DotGroup/DotGroup.jsx
@@ -38,7 +38,8 @@ const DotGroup = class DotGroup extends React.Component {
     } = this.props;
 
     if (renderDots) {
-      return renderDots(this.props);
+      const { renderDots: _, ...renderProps } = this.props;
+      return renderDots(renderProps);
     }
 
     const dots = [];

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -75,11 +75,26 @@ type ImageInterface = React.ComponentClass<ImageProps>
 declare const Image: ImageInterface
 
 
+interface RenderDotsProps {
+  readonly currentSlide?: number,
+  readonly totalSlides?: number,
+  readonly visibleSlides?: number,
+  readonly disableActiveDots?: boolean,
+  readonly showAsSelectedForCurrentSlideOnly?: boolean,
+}
+
+type RenderDotsFunction = (props: RenderDotsProps) => void
 
 interface DotGroupProps {
   readonly children?: React.ReactNode
   readonly className?: string
   readonly dotNumbers?: boolean
+  readonly currentSlide?: number,
+  readonly totalSlides?: number,
+  readonly visibleSlides?: number,
+  readonly disableActiveDots?: boolean,
+  readonly showAsSelectedForCurrentSlideOnly?: boolean,
+  readonly renderDots?: RenderDotsFunction,
 }
 type DotGroupInterface = React.ComponentClass<DotGroupProps>
 /**


### PR DESCRIPTION
**What**:

* Add Typescript typings for the `renderDots` method
* Avoid passing the custom renderDots method back to itself

**Why**:

Could not use the `renderDots` method while using Typescript. 
I removed the parameter because it was unneeded

**Checklist**:

- [ ] Documentation added/updated (N/A)
- [x] Typescript definitions updated
- [x] Tests added and passing (N/A)
- [x ] Ready to be merged 

fixes #182 
