### PR TITLE
feature: infinite scroll works with swiping as well as buttons

### DIFF
--- a/src/App/examples/Example12/Example12.jsx
+++ b/src/App/examples/Example12/Example12.jsx
@@ -18,9 +18,10 @@ export default () => (
   >
     <h2 className={s.headline}>Infinite Carousel</h2>
     <p>
-      A carousel that returns to the first slide if the user clicks the Next button while on the
-      last slide and returns to the last slide if the user clicks the Back
-      button while on the first slide.
+      A carousel that returns to the first slide if the user clicks the Next
+      button while on the last slide and returns to the last slide if the user
+      clicks the Back button while on the first slide. Also behaves similarly
+      with swiping left on the first image or right on the last image.
     </p>
     <Slider className={s.slider}>
       <Slide index={0}>

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -21,6 +21,7 @@ const Slider = class Slider extends React.Component {
     dragEnabled: PropTypes.bool.isRequired,
     dragStep: PropTypes.number,
     hasMasterSpinner: PropTypes.bool.isRequired,
+    infinite: PropTypes.bool,
     interval: PropTypes.number.isRequired,
     isPageScrollLocked: PropTypes.bool.isRequired,
     isPlaying: PropTypes.bool.isRequired,
@@ -64,6 +65,7 @@ const Slider = class Slider extends React.Component {
     disableAnimation: false,
     disableKeyboard: false,
     dragStep: 1,
+    infinite: false,
     moveThreshold: 0.1,
     onMasterSpinner: null,
     privateUnDisableAnimation: false,
@@ -456,11 +458,20 @@ const Slider = class Slider extends React.Component {
       this.props.totalSlides, this.props.visibleSlides,
     );
 
-    const currentSlide = boundedRange({
+    let currentSlide = boundedRange({
       min: 0,
       max: maxSlide,
       x: (this.props.currentSlide + slidesMoved),
     });
+
+    if (this.props.infinite) {
+      if (this.props.currentSlide >= maxSlide && slidesMoved > 0) {
+        currentSlide = 0;
+      }
+      if (this.props.currentSlide === 0 && slidesMoved < 0) {
+        currentSlide = maxSlide;
+      }
+    }
 
     this.props.carouselStore.setStoreState({
       currentSlide,

--- a/src/Slider/__tests__/Slider.test.jsx
+++ b/src/Slider/__tests__/Slider.test.jsx
@@ -628,6 +628,42 @@ describe('<Slider />', () => {
       expect(props.carouselStore.state.currentSlide).toBe(3);
     });
 
+    it('Should set the slider to last set of visible slides on touchend when dragging the slider past the start of the slide show and infinite is set to true.', () => {
+      const wrapper = mount(<Slider {...props} infinite currentSlide={0} />);
+      const instance = wrapper.instance();
+      wrapper.setState({
+        deltaX: 1000,
+        deltaY: 0,
+      });
+      wrapper.update();
+      instance.sliderTrayElement = {
+        clientWidth: 500,
+        clientHeight: 100,
+      };
+      wrapper.find('.sliderTray').simulate('touchend', { targetTouches: [] });
+      expect(props.carouselStore.state.currentSlide).toBe(
+        props.totalSlides - props.visibleSlides,
+      );
+    });
+
+    it('Should set the slider to first set of visible slides on touchend when dragging the slider past the end of the last slide and infinite is set to true.', () => {
+      const wrapper = mount(
+        <Slider {...props} infinite currentSlide={props.totalSlides - 1} />,
+      );
+      const instance = wrapper.instance();
+      wrapper.setState({
+        deltaX: -1000,
+        deltaY: 0,
+      });
+      wrapper.update();
+      instance.sliderTrayElement = {
+        clientWidth: 500,
+        clientHeight: 100,
+      };
+      wrapper.find('.sliderTray').simulate('touchend', { targetTouches: [] });
+      expect(props.carouselStore.state.currentSlide).toBe(0);
+    });
+
     it('should not change the state at all when touchEnd and touchEnabled prop is false', () => {
       const wrapper = shallow(<Slider {...props} touchEnabled={false} />);
       // nonsense values to test that slider state is not reset on touchend

--- a/src/Slider/index.js
+++ b/src/Slider/index.js
@@ -8,6 +8,7 @@ export default WithStore(Slider, state => ({
   disableKeyboard: state.disableKeyboard,
   dragEnabled: state.dragEnabled,
   hasMasterSpinner: state.hasMasterSpinner,
+  infinite: state.infinite,
   interval: state.interval,
   isPageScrollLocked: state.isPageScrollLocked,
   isPlaying: state.isPlaying,

--- a/src/helpers/component-config.js
+++ b/src/helpers/component-config.js
@@ -153,6 +153,7 @@ export default {
       dragEnabled: true,
       hasMasterSpinner: false,
       interval: 5000,
+      infinite: false,
       isPageScrollLocked: false,
       isPlaying: false,
       lockOnWindowScroll: false,


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

There was a recent addition to allow infinite scrolling with the buttons and with autoplay, but this isn't currently happening when a user swipes at the start or end of the carousel. This PR changes that.

**Why**:

When a user is swiping through pictures and hits the end of the carousel, it is cumbersome to have to swipe back through all of the photos instead of continuing to swipe forward.

**How**:

Modifying the computeCurrentSlide to account for when infinite is set to true.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
Love what the team is doing with this! Thank you for the great package!

![Nov-12-2019 15-16-56](https://user-images.githubusercontent.com/29843005/68718924-8800b080-055f-11ea-950a-a96071f6ed90.gif)
