### PR TITLE
Fixed naming issue for ButtonNext types

### DIFF
--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -206,7 +206,7 @@ export {
   DotGroupProps,
   DotProps,
   ButtonBackProps,
-  ButtonNextInterface,
+  ButtonNextProps,
   ButtonLastProps,
   ButtonFirstProps,
   ButtonPlayProps

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,7 @@ import {
   DotGroupProps,
   DotProps,
   ButtonBackProps,
-  ButtonNextInterface,
+  ButtonNextProps,
   ButtonLastProps,
   ButtonFirstProps,
   ButtonPlayProps
@@ -166,7 +166,7 @@ export {
   DotGroupProps,
   DotProps,
   ButtonBackProps,
-  ButtonNextInterface,
+  ButtonNextProps,
   ButtonLastProps,
   ButtonFirstProps,
   ButtonPlayProps


### PR DESCRIPTION
Changed naming so that correct types are exported for ButtonNext

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Changed name from `buttonNextInterface` to `buttonNextProps`

**Why**:

It was incorrectly exporting interface instead of props

**How**:

Renamed exported type name

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [x] Typescript definitions updated
- [ ] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->
