### PR TITLE
Add missing types definition into CarouselStoreInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ Note that you will likely need to subscribe/unsubscribe to changes in order to t
 Example:
 
 ```js
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { CarouselContext } from 'pure-react-carousel';
 
 export function MyComponentUsingContext() {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -59,11 +59,11 @@ interface CarouselStoreInterface {
   readonly subscribe: (func: () => void) => void
   readonly unsubscribe: (func: () => void) => void
   readonly updateSubscribers: (cb?: (state: CarouselState) => void) => void
-  readonly subscribeMasterSpinner: (src) => void
-  readonly unsubscribeMasterSpinner: (src) => false | object
+  readonly subscribeMasterSpinner: (src: string) => void
+  readonly unsubscribeMasterSpinner: (src: string) => false | object
   readonly unsubscribeAllMasterSpinner: () => void
-  readonly masterSpinnerSuccess: (src) => void
-  readonly masterSpinnerError: (src) => void
+  readonly masterSpinnerSuccess: (src: string) => void
+  readonly masterSpinnerError: (src: string) => void
   readonly setMasterSpinnerFinished: () => void
   readonly isMasterSpinnerFinished: () => boolean
 }


### PR DESCRIPTION
**What**: 
  Udapte types definition into CarouselStoreInterface
  Add missing library into README.md

**Why**:
  Parameter 'src' implicitly had an 'any' type.

**How**:
  Update next lines
`readonly subscribeMasterSpinner: (src: string) => void`
`readonly unsubscribeMasterSpinner: (src: string) => false | object`
`readonly masterSpinnerSuccess: (src: string) => void`
`readonly masterSpinnerError: (src: string) => void`

**Checklist**:

- [x] Documentation added/updated
- [x] Typescript definitions updated
_- [ N/A ] Tests added and passing, no behavioural change_
- [x] Ready to be merged

Tracking from the last commit made by @saleb #235 
