### PR TITLE
fix: prevent `currentSlide` from going out of bounds of `totalSlides`

### DIFF
--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -133,6 +133,10 @@ const CarouselProvider = class CarouselProvider extends React.Component {
       newStoreState.slideTraySize = slideTraySize(this.props.totalSlides, this.props.visibleSlides);
     }
 
+    if (this.carouselStore.state.currentSlide >= this.props.totalSlides) {
+      newStoreState.currentSlide = this.props.totalSlides - 1;
+    }
+
     if (Object.keys(newStoreState).length > 0) {
       this.carouselStore.setStoreState(newStoreState);
     }

--- a/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
+++ b/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
@@ -49,6 +49,12 @@ describe('<CarouselProvider />', () => {
     expect(instance.carouselStore.state.slideSize).toBe(25);
     expect(instance.carouselStore.state.slideTraySize).toBe(200);
   });
+  it('should keep currentSlide within bounds of totalSlides', () => {
+    const wrapper = shallow(<CarouselProvider {...props} currentSlide={3} totalSlides={4} />);
+    const instance = wrapper.instance();
+    wrapper.setProps({ totalSlides: 3 });
+    expect(instance.carouselStore.state.currentSlide).toEqual(2);
+  });
   it('should not update the carouselStore if some prop we do not track changes', () => {
     const wrapper = shallow(<CarouselProvider {...props} data-foo={1} />);
     const instance = wrapper.instance();
@@ -58,7 +64,7 @@ describe('<CarouselProvider />', () => {
     expect(start).toEqual(end);
   });
   it('should not reset the currentSlide or disableAnimation values when unrelated props change', () => {
-    const wrapper = shallow(<CarouselProvider {...props} data-foo={1} />);
+    const wrapper = shallow(<CarouselProvider {...props} totalSlides={4} data-foo={1} />);
     const instance = wrapper.instance();
     instance.carouselStore.setStoreState({ currentSlide: 2 });
     const start = clone(instance.carouselStore.state);


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Prevent `currentSlide` from going out of bounds of `totalSlides`.

**Why**:

It's possible for a component to dynamically change the number of slides. If the number of slides is reduced such that `currentSlide` is past `totalSlides`, it results in a blank view.

**How**:

On `CarouselProvider`s update, `currentSlide` is being constrained to `totalSlides - 1` (i.e. the last slide).

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added/updated~ N/A, bugfix
- ~[ ] Typescript definitions updated~ N/A, no type changes
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
