### PR TITLE
Prevent negative slide number

### DIFF
--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -140,7 +140,7 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     }
 
     if (this.carouselStore.state.currentSlide >= this.props.totalSlides) {
-      newStoreState.currentSlide = this.props.totalSlides - 1;
+      newStoreState.currentSlide = Math.max(this.props.totalSlides - 1, 0);
     }
 
     if (Object.keys(newStoreState).length > 0) {

--- a/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
+++ b/src/CarouselProvider/__tests__/CarouselProvider.test.jsx
@@ -73,7 +73,7 @@ describe('<CarouselProvider />', () => {
     expect(start.currentSlide).toEqual(end.currentSlide);
     expect(start.disableAnimation).toEqual(end.disableAnimation);
   });
-  it('should set disableAnimation to true and privatUnDisableAnimation to true if we updated currentSlide prop on CarouselProvider component', async () => {
+  it('should set disableAnimation to true and privateUnDisableAnimation to true if we updated currentSlide prop on CarouselProvider component', async () => {
     const wrapper = mount(
       <CarouselProvider {...props}>Hello</CarouselProvider>,
     );
@@ -83,7 +83,7 @@ describe('<CarouselProvider />', () => {
       true,
     );
   });
-  it('The Slider component should reset disableAnimation to false and privatUnDisableAnimation to false if when Slider component is updated', async () => {
+  it('The Slider component should reset disableAnimation to false and privateUnDisableAnimation to false if when Slider component is updated', async () => {
     const wrapper = mount(
       <CarouselProvider {...props}>
         <Slider>Hello</Slider>
@@ -103,7 +103,7 @@ describe('<CarouselProvider />', () => {
     );
     expect(wrapper.instance().getStore().state.isIntrinsicHeight).toBe(true);
   });
-  it('should throw an error, when tryng to use isIntrinsicHeight in vertical orientation', async () => {
+  it('should throw an error, when trying to use isIntrinsicHeight in vertical orientation', async () => {
     expect(() => shallow(
       <CarouselProvider {...props} isIntrinsicHeight orientation="vertical">
         test


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

This prevents the current slide from becoming -1 during re-renders under certain conditions. This is a fix for issue #247 

**Why**:

You shouldn't have a negative number slide.

**How**:

Updated CarouselProvider.jsx

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated N/A
- [ ] Typescript definitions updated N/A
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
