### PR TITLE
fix: autoplay interval bug

### DIFF
--- a/src/ButtonBack/ButtonBack.jsx
+++ b/src/ButtonBack/ButtonBack.jsx
@@ -55,6 +55,7 @@ export default class ButtonBack extends React.Component {
     carouselStore.setStoreState(
       {
         currentSlide: newCurrentSlide,
+        isPlaying: false,
       },
       onClick !== null && onClick.call(this, ev),
     );

--- a/src/ButtonBack/__tests__/ButtonBack.test.jsx
+++ b/src/ButtonBack/__tests__/ButtonBack.test.jsx
@@ -191,4 +191,20 @@ describe('<ButtonBack />', () => {
     );
     expect(wrapper.find('button').prop('foo')).toEqual('bar');
   });
+  it('should pause autoplay when clicked', () => {
+    const wrapper = mount(
+      <CarouselProvider
+        naturalSlideWidth={100}
+        naturalSlideHeight={125}
+        totalSlides={3}
+        currentSlide={1}
+        step={3}
+        isPlaying
+      >
+        <ButtonBackWithStore>Hello</ButtonBackWithStore>
+      </CarouselProvider>
+    );
+    wrapper.find('button').simulate('click');
+    expect(wrapper.instance().getStore().state.isPlaying).toBe(false);
+  });
 });

--- a/src/ButtonBack/__tests__/ButtonBack.test.jsx
+++ b/src/ButtonBack/__tests__/ButtonBack.test.jsx
@@ -202,7 +202,7 @@ describe('<ButtonBack />', () => {
         isPlaying
       >
         <ButtonBackWithStore>Hello</ButtonBackWithStore>
-      </CarouselProvider>
+      </CarouselProvider>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.instance().getStore().state.isPlaying).toBe(false);

--- a/src/ButtonFirst/ButtonFirst.jsx
+++ b/src/ButtonFirst/ButtonFirst.jsx
@@ -29,6 +29,7 @@ const ButtonFirst = class ButtonFirst extends React.Component {
     const { carouselStore, onClick } = this.props;
     carouselStore.setStoreState({
       currentSlide: 0,
+      isPlaying: false,
     }, onClick !== null && onClick.call(this, ev));
   }
 

--- a/src/ButtonFirst/ButtonFirst.jsx
+++ b/src/ButtonFirst/ButtonFirst.jsx
@@ -35,7 +35,13 @@ const ButtonFirst = class ButtonFirst extends React.Component {
 
   render() {
     const {
-      carouselStore, className, currentSlide, disabled, onClick, totalSlides, ...props
+      carouselStore,
+      className,
+      currentSlide,
+      disabled,
+      onClick,
+      totalSlides,
+      ...props
     } = this.props;
 
     const newClassName = cn([

--- a/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
+++ b/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
@@ -40,4 +40,9 @@ describe('<ButtonFirst />', () => {
     wrapper.find('button').simulate('click');
     expect(onClick.mock.calls.length).toBe(1);
   });
+  it('should pause autoplay when clicked', () => {
+    const wrapper = mount(<ButtonFirst {...props} />);
+    wrapper.find('button').simulate('click');
+    expect(props.carouselStore.getStoreState().isPlaying).toBe(false);
+  });
 });

--- a/src/ButtonLast/ButtonLast.jsx
+++ b/src/ButtonLast/ButtonLast.jsx
@@ -33,6 +33,7 @@ const ButtonLast = class ButtonLast extends React.Component {
     carouselStore.setStoreState(
       {
         currentSlide: totalSlides - visibleSlides,
+        isPlaying: false,
       },
       onClick !== null && onClick.call(this, ev),
     );

--- a/src/ButtonLast/__tests__/ButtonLast.test.jsx
+++ b/src/ButtonLast/__tests__/ButtonLast.test.jsx
@@ -70,4 +70,14 @@ describe('<ButtonLast />', () => {
     const wrapper = shallow(<ButtonLast {...newProps} />);
     expect(wrapper.prop('disabled')).toBe(false);
   });
+  it('should pause autoplay when clicked', () => {
+    const newProps = Object.assign({}, props, {
+      carouselStore: new Store({
+        isPlaying: true,
+      }),
+    });
+    const wrapper = mount(<ButtonLast {...newProps} />);
+    wrapper.find('button').simulate('click');
+    expect(newProps.carouselStore.getStoreState().isPlaying).toBe(false);
+  });
 });

--- a/src/ButtonNext/ButtonNext.jsx
+++ b/src/ButtonNext/ButtonNext.jsx
@@ -56,6 +56,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
     carouselStore.setStoreState(
       {
         currentSlide: newCurrentSlide,
+        isPlaying: false,
       },
       onClick !== null && onClick.call(this, ev),
     );

--- a/src/ButtonNext/__tests__/ButtonNext.test.jsx
+++ b/src/ButtonNext/__tests__/ButtonNext.test.jsx
@@ -162,7 +162,7 @@ describe('<ButtonNext />', () => {
         isPlaying
       >
         <ButtonNextWithStore>Hello</ButtonNextWithStore>
-      </CarouselProvider>
+      </CarouselProvider>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.instance().getStore().state.isPlaying).toBe(false);

--- a/src/ButtonNext/__tests__/ButtonNext.test.jsx
+++ b/src/ButtonNext/__tests__/ButtonNext.test.jsx
@@ -151,4 +151,20 @@ describe('<ButtonNext />', () => {
     expect(instance.carouselStore.state.currentSlide).toBe(newProps.totalSlides - newProps.visibleSlides);
     expect(wrapper.find('button').prop('disabled')).toBe(true);
   });
+  it('should pause autoplay when clicked', () => {
+    const wrapper = mount(
+      <CarouselProvider
+        naturalSlideWidth={100}
+        naturalSlideHeight={125}
+        totalSlides={3}
+        currentSlide={1}
+        step={3}
+        isPlaying
+      >
+        <ButtonNextWithStore>Hello</ButtonNextWithStore>
+      </CarouselProvider>
+    );
+    wrapper.find('button').simulate('click');
+    expect(wrapper.instance().getStore().state.isPlaying).toBe(false);
+  });
 });

--- a/src/Dot/Dot.jsx
+++ b/src/Dot/Dot.jsx
@@ -37,6 +37,7 @@ const Dot = class Dot extends React.Component {
 
     carouselStore.setStoreState({
       currentSlide: newSlide,
+      isPlaying: false,
     }, onClick !== null && onClick.call(this, ev));
   }
 

--- a/src/Dot/__tests__/Dot.test.jsx
+++ b/src/Dot/__tests__/Dot.test.jsx
@@ -59,4 +59,9 @@ describe('<Dot />', () => {
     const wrapper = mount(<Dot {...props} slide={0} disabled />);
     expect(wrapper.find('button').prop('disabled')).toBe(true);
   });
+  it('should pause autoplay when clicked', () => {
+    const wrapper = mount(<Dot {...props} slide={10} />);
+    wrapper.find('button').simulate('click');
+    expect(props.carouselStore.getStoreState().isPlaying).toBe(false);
+  });
 });


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Fixes #252 

Automatically pause "autoplay" (`isPlaying`) when the user changes slides using one of these HOC control components:

* `<ButtonNext />`
* `<ButtonBack />`
* `<ButtonFirst />`
* `<ButtonLast />`
* `<Dot />`

This mirrors the existing behavior where autoplay is paused when the user interacts with the Slider (i.e. drags on mobile).

**Why**:

Currently, the isPlaying interval timer doesn't reset when the user visits a slide using one of these buttons. The end result (as defined in #252) is that a user could progress to a slide and then immediately be progressed to another slide. I don't see why the user would EVER want this to happen.

**How**:

Set `isPlaying: false` in the CarouselProvider state in the onClick handler for each of the aforementioned HOCs.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated (N/A)
- [ ] Typescript definitions updated (N/A)
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
I meant to create a `bugfix/*` branch in my repo to merge in but accidentally committed to Master instead; NBD.