### PR TITLE
feat: Add className props to ImageWithZoom

### DIFF
--- a/src/ImageWithZoom/ImageWithZoom.jsx
+++ b/src/ImageWithZoom/ImageWithZoom.jsx
@@ -13,6 +13,9 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
   static propTypes = {
     // alt: PropTypes.string,
     carouselStore: PropTypes.object.isRequired,
+    className: PropTypes.string,
+    imageClassName: PropTypes.string,
+    overlayClassName: PropTypes.string,
     spinner: PropTypes.func,
     src: PropTypes.string.isRequired,
     srcZoomed: PropTypes.string,
@@ -21,6 +24,9 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
   }
 
   static defaultProps = {
+    className: null,
+    imageClassName: null,
+    overlayClassName: null,
     isPinchZoomEnabled: true,
     spinner: null,
     srcZoomed: null,
@@ -264,6 +270,9 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
   render() {
     const {
       carouselStore,
+      className,
+      imageClassName,
+      overlayClassName,
       isPinchZoomEnabled,
       spinner,
       src,
@@ -272,18 +281,25 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
       ...filteredProps
     } = this.props;
 
-    const imageClassName = cn([
-      s.image,
-      'carousel__zoom-image',
+    const newClassName = cn([
+      s.container,
+      className,
     ]);
 
-    const overlayClassName = cn([
+    const newImageClassName = cn([
+      s.image,
+      'carousel__zoom-image',
+      imageClassName,
+    ]);
+
+    const newOverlayClassName = cn([
       s.overlay,
       'carousel__zoom-image-overlay',
       this.state.isHovering && s.hover,
       this.state.isZooming && s.zoom,
       this.state.isHovering && 'carousel__zoom-image-overlay--hovering',
       this.state.isZooming && 'carousel__zoom-image-overlay--zooming',
+      overlayClassName,
     ]);
 
     const overlayStyle = {};
@@ -293,9 +309,9 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
     }
 
     return (
-      <Tag className={s.container} {...filteredProps}>
+      <Tag className={newClassName} {...filteredProps}>
         <Image
-          className={imageClassName}
+          className={newImageClassName}
           tag="div"
           src={src}
           isBgImage
@@ -303,7 +319,7 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
           onError={this.handleImageComplete}
         />
         <Image
-          className={overlayClassName}
+          className={newOverlayClassName}
           tag="div"
           src={srcZoomed || src}
           style={overlayStyle}

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -47,9 +47,13 @@ declare const Slide: SlideInterface
 
 
 interface ImageWithZoomProps {
+  readonly className?: string
+  readonly imageClassName?: string
+  readonly overlayClassName?: string
   readonly src: string
   readonly srcZoomed?: string
   readonly tag?: string
+  readonly isPinchZoomEnabled?: boolean
 }
 type ImageWithZoomInterface = React.ComponentClass<ImageWithZoomProps>
 declare const ImageWithZoom: ImageWithZoomInterface


### PR DESCRIPTION
**What**:

The following props have been added to the `ImageWithZoom` component:

- `className`
- `imageClassName`
- `overlayClassName`

**Why**:

Before this change, it was impossible to add `className`s to the `ImageWithZoom` image and overlay components.  
Additionally, if a `className` was added to the container component via `filteredProps`, the container lost its existing styles.

**How**:

The new props were added in a manner which reflects the `Image` component's `className` prop.

**Checklist**:

- [x] Documentation added/updated (N/A)
  - `ImageWithZoom` doesn't appear to have its own documentation separate to that of the `Image` component.
- [x] Typescript definitions updated
- [x] Tests added and passing (N/A)
- [x] Ready to be merged
