### PR TITLE
bugfix: IE isIntrinsicHeight

### DIFF
--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -122,13 +122,13 @@ const Slide = class Slide extends React.PureComponent {
     const innerStyle = {};
     if (isIntrinsicHeight) {
       if (orientation === 'horizontal') {
-        tempStyle.height = 'unset';
+        tempStyle.height = 'auto';
       } else {
-        tempStyle.width = 'unset';
+        tempStyle.width = 'auto';
       }
-      tempStyle.position = 'unset';
+      tempStyle.position = 'static';
       tempStyle.paddingBottom = 'unset';
-      innerStyle.position = 'unset';
+      innerStyle.position = 'static';
     }
 
     const newStyle = Object.assign({}, tempStyle, style);


### PR DESCRIPTION
**What**:

Carousel height = 0 in IE when `isIntrinsicHeight = true`

**Why**:

IE does not support the `unset` property.

As result:
- slide height = 0
- slide inner position = absolute
