### PR TITLE
fix: RTL support

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -13,6 +13,7 @@ import {
   Example11,
   Example12,
   Example13,
+  Example14,
 } from './examples';
 import s from './style.scss';
 
@@ -244,6 +245,13 @@ class DevelopmentApp extends React.Component {
               <section id="example--13">
                 <hr />
                 <Example13 />
+              </section>
+              )}
+
+              {(value === '0' || value === '14') && (
+              <section id="example--14">
+                <hr />
+                <Example14 />
               </section>
               )}
 

--- a/src/App/examples/Example14/Example14.jsx
+++ b/src/App/examples/Example14/Example14.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import
+{
+  ButtonBack, ButtonFirst, ButtonLast, ButtonNext, CarouselProvider, Slide, Slider,
+} from '../../..';
+
+import s from '../../style.scss';
+import ImageWithZoom from '../../../ImageWithZoom/ImageWithZoom';
+
+export default () => (
+  <CarouselProvider
+    visibleSlides={2}
+    totalSlides={8}
+    step={1}
+    naturalSlideWidth={400}
+    naturalSlideHeight={500}
+  >
+    <h2 className={s.headline}>RTL</h2>
+    <p>
+      A carousel wrapped in an element with
+      {' '}
+      <code>dir=&quot;rtl&quot;</code>
+, demonstrating support for use with right-to-left languages.
+    </p>
+    <div dir="rtl">
+      <Slider className={s.slider}>
+        <Slide index={0}>
+          <ImageWithZoom src="./media/img01.jpeg" />
+        </Slide>
+        <Slide index={1}>
+          <ImageWithZoom src="./media/img02.jpeg" />
+        </Slide>
+        <Slide index={2}>
+          <ImageWithZoom src="./media/img03.jpeg" />
+        </Slide>
+        <Slide index={3}>
+          <ImageWithZoom src="./media/img04.jpeg" />
+        </Slide>
+        <Slide index={4}>
+          <ImageWithZoom src="./media/img05.jpeg" />
+        </Slide>
+        <Slide index={5}>
+          <ImageWithZoom src="./media/img06.jpeg" />
+        </Slide>
+        <Slide index={6}>
+          <ImageWithZoom src="./media/img07.jpeg" />
+        </Slide>
+        <Slide index={7}>
+          <ImageWithZoom src="./media/img08.jpeg" />
+        </Slide>
+      </Slider>
+      <ButtonFirst>First</ButtonFirst>
+      <ButtonBack>Back</ButtonBack>
+      <ButtonNext>Next</ButtonNext>
+      <ButtonLast>Last</ButtonLast>
+    </div>
+  </CarouselProvider>
+);

--- a/src/App/examples/Example14/Example14.jsx
+++ b/src/App/examples/Example14/Example14.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import
 {
-  ButtonBack, ButtonFirst, ButtonLast, ButtonNext, CarouselProvider, Slide, Slider, ImageWithZoom, DotGroup
+  ButtonBack,
+  ButtonFirst,
+  ButtonLast,
+  ButtonNext,
+  CarouselProvider,
+  Slide,
+  Slider,
+  ImageWithZoom,
+  DotGroup,
 } from '../../..';
 
 import s from '../../style.scss';

--- a/src/App/examples/Example14/Example14.jsx
+++ b/src/App/examples/Example14/Example14.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import
 {
-  ButtonBack, ButtonFirst, ButtonLast, ButtonNext, CarouselProvider, Slide, Slider,
+  ButtonBack, ButtonFirst, ButtonLast, ButtonNext, CarouselProvider, Slide, Slider, ImageWithZoom, DotGroup
 } from '../../..';
 
 import s from '../../style.scss';
-import ImageWithZoom from '../../../ImageWithZoom/ImageWithZoom';
 
 export default () => (
   <CarouselProvider
@@ -53,6 +52,7 @@ export default () => (
       <ButtonBack>Back</ButtonBack>
       <ButtonNext>Next</ButtonNext>
       <ButtonLast>Last</ButtonLast>
+      <DotGroup dotNumbers />
     </div>
   </CarouselProvider>
 );

--- a/src/App/examples/Example14/index.js
+++ b/src/App/examples/Example14/index.js
@@ -1,0 +1,3 @@
+import Example14 from './Example14';
+
+export default Example14;

--- a/src/App/examples/index.js
+++ b/src/App/examples/index.js
@@ -11,3 +11,4 @@ export { default as Example10 } from './Example10';
 export { default as Example11 } from './Example11';
 export { default as Example12 } from './Example12';
 export { default as Example13 } from './Example13';
+export { default as Example14 } from './Example14';

--- a/src/Slide/Slide.scss
+++ b/src/Slide/Slide.scss
@@ -12,6 +12,13 @@
 
   &Horizontal {
     float: left;
+
+    [dir='rtl'] & {
+      > * {
+        direction: rtl;
+        transform: scaleX(-1);
+      }
+    }
   }
 
   &Inner {

--- a/src/Slide/Slide.scss
+++ b/src/Slide/Slide.scss
@@ -14,10 +14,8 @@
     float: left;
 
     [dir='rtl'] & {
-      > * {
-        direction: rtl;
-        transform: scaleX(-1);
-      }
+      direction: rtl;
+      transform: scaleX(-1);
     }
   }
 

--- a/src/Slider/Slider.scss
+++ b/src/Slider/Slider.scss
@@ -1,6 +1,7 @@
 .horizontalSlider {
   position: relative;
   overflow: hidden;
+  direction: ltr;
 
   &Tray {
     overflow: hidden;

--- a/src/Slider/Slider.scss
+++ b/src/Slider/Slider.scss
@@ -1,7 +1,11 @@
 .horizontalSlider {
   position: relative;
   overflow: hidden;
-  direction: ltr;
+
+  [dir='rtl'] & {
+    direction: ltr;
+    transform: scaleX(-1);
+  }
 
   &Tray {
     overflow: hidden;


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adds RTL support to fix https://github.com/express-labs/pure-react-carousel/issues/266

**Why**:

<!-- Why are these changes necessary? -->
Allows the carousel content to be accessed when used on RTL pages, and updates the slide direction to match the direction of the text

**How**:

<!-- How were these changes implemented? -->
Adding `[dir="rtl"] &` selectors which flips the slider such that the slides are reversed and it visually translates in the opposite direction, and also flips each slide such that their content is not reversed.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated (N/A)
- [x] Tests added and passing (N/A)
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
The global attribute selector used to solve this issue feels a little hacky, but afaik there is no CSS-only solution which is more robust (the `:dir` pseudo-selector would be nice, but it doesn't have wide browser support)