### PR TITLE
Closes #269 : make dot children prop optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ A Dot component is a HTML button.  Dots directly correlate to slides.  Clicking 
 
 | property | type | default | required | purpose |
 | -------- | ---- | ------- | -------- | ------- |
-| **children** | [string&#124;node] | | **Yes** | Children is a special React property.  Basically, the Dot component needs to wrap other components and/or JSX |
+| children | [string&#124;null&#124;node] | null | No | Children is a special React property.  Basically, the Dot component wraps other components and/or JSX |
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means Dot will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |

--- a/src/Dot/Dot.jsx
+++ b/src/Dot/Dot.jsx
@@ -6,7 +6,7 @@ import s from './Dot.scss';
 const Dot = class Dot extends React.Component {
   static propTypes = {
     carouselStore: PropTypes.object.isRequired,
-    children: CarouselPropTypes.children.isRequired,
+    children: CarouselPropTypes.children,
     className: PropTypes.string,
     currentSlide: PropTypes.number.isRequired,
     disabled: PropTypes.bool,
@@ -18,6 +18,7 @@ const Dot = class Dot extends React.Component {
   }
 
   static defaultProps = {
+    children: null,
     className: null,
     disabled: null,
     onClick: null,

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -110,7 +110,7 @@ declare const DotGroup: DotGroupInterface
 
 
 interface DotProps {
-  readonly children: React.ReactChild
+  readonly children?: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: () => void


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Made children of Dot component optional

**Why**:

See issue #269 - when using Dot directly, there may no need to have any children

**How**:

Changed props and updated docs (hopefully :) )

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated (
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
