### PR TITLE
Add missing className for ButtonPlayProps typing

### DIFF
--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -183,6 +183,7 @@ declare const ButtonFirst: ButtonLastInterface
 interface ButtonPlayProps {
   readonly childrenPaused?: React.ReactNode
   readonly childrenPlaying?: React.ReactNode
+  readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
 }


### PR DESCRIPTION
**What**:

Added missing className typing for ButtonPlayProps interface 

**Why**:

ButtonPlay has ability to set custom className (and its already documented)

**How**:

Changes were implemented for TS typings

**Checklist**:

- [ ] Documentation added/updated (N/A)
- [x] Typescript definitions updated
- [ ] Tests added and passing (N/A)
- [x] Ready to be merged <!-- In your opinion -->
