### PR TITLE
Update typings to include trayProps

### DIFF
--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -11,6 +11,7 @@ interface SliderProps {
   readonly style?: {}
   readonly spinner?: () => void
   readonly trayTag?: string
+  readonly trayProps?: React.HTMLAttributes<HTMLUListElement>
 }
 type SliderInterface = React.ComponentClass<SliderProps>
 /**

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-interface SliderProps {
+interface SliderProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly children: React.ReactNode
   readonly className?: string
   readonly classNameAnimation?: string

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -21,7 +21,7 @@ declare const Slider: SliderInterface
 
 
 
-interface SlideProps {
+interface SlideProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly className?: string
   readonly classNameHidden?: string
   readonly classNameVisible?: string
@@ -61,7 +61,7 @@ declare const ImageWithZoom: ImageWithZoomInterface
 
 
 
-interface ImageProps {
+interface ImageProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly alt?: string
   readonly children?: React.ReactNode
   readonly className?: string
@@ -91,7 +91,7 @@ interface RenderDotsProps {
 
 type RenderDotsFunction = (props: RenderDotsProps) => void
 
-interface DotGroupProps {
+interface DotGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly children?: React.ReactNode
   readonly className?: string
   readonly dotNumbers?: boolean
@@ -110,7 +110,7 @@ declare const DotGroup: DotGroupInterface
 
 
 
-interface DotProps {
+interface DotProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly children?: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
@@ -125,7 +125,7 @@ declare const Dot: DotInterface
 
 
 
-interface ButtonNextProps {
+interface ButtonNextProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly children: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
@@ -139,7 +139,7 @@ declare const ButtonNext: ButtonNextInterface
 
 
 
-interface ButtonBackProps {
+interface ButtonBackProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly children: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
@@ -153,7 +153,7 @@ declare const ButtonBack: ButtonBackInterface
 
 
 
-interface ButtonLastProps {
+interface ButtonLastProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly children: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
@@ -167,7 +167,7 @@ declare const ButtonLast: ButtonLastInterface
 
 
 
-interface ButtonFirstProps {
+interface ButtonFirstProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly children: React.ReactChild
   readonly className?: string
   readonly disabled?: boolean
@@ -181,7 +181,7 @@ declare const ButtonFirst: ButtonLastInterface
 
 
 
-interface ButtonPlayProps {
+interface ButtonPlayProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly childrenPaused?: React.ReactNode
   readonly childrenPlaying?: React.ReactNode
   readonly className?: string


### PR DESCRIPTION
This prop is supported by Slider but is not included in typings

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: Add trayProps to type definition. It is already a feature as outlined by the documentation

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: Users who are using typescript do not have direct access to trayProps without adding custom typings

<!-- Why are these changes necessary? -->

**How**: Add typing to carouselElements.d.ts

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [x] Typescript definitions updated
- [ ] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
