### PR TITLE
feat: add infinite functionality

### DIFF
--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -77,8 +77,8 @@ const CarouselProvider = class CarouselProvider extends React.Component {
       orientation: props.orientation,
       playDirection: props.playDirection,
       privateUnDisableAnimation: false,
-      slideSize: slideSize(props.totalSlides, props.visibleSlides),
-      slideTraySize: slideTraySize(props.totalSlides, props.visibleSlides),
+      slideSize: slideSize(props.totalSlides, props.visibleSlides, props.infinite),
+      slideTraySize: slideTraySize(props.totalSlides, props.visibleSlides, props.infinite),
       step: props.step,
       dragStep: props.dragStep,
       totalSlides: props.totalSlides,
@@ -135,8 +135,8 @@ const CarouselProvider = class CarouselProvider extends React.Component {
       this.props.totalSlides !== prevProps.totalSlides
       || this.props.visibleSlides !== prevProps.visibleSlides
     ) {
-      newStoreState.slideSize = slideSize(this.props.totalSlides, this.props.visibleSlides);
-      newStoreState.slideTraySize = slideTraySize(this.props.totalSlides, this.props.visibleSlides);
+      newStoreState.slideSize = slideSize(this.props.totalSlides, this.props.visibleSlides, this.props.infinite);
+      newStoreState.slideTraySize = slideTraySize(this.props.totalSlides, this.props.visibleSlides, this.props.infinite);
     }
 
     if (this.carouselStore.state.currentSlide >= this.props.totalSlides) {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -16,12 +16,14 @@ export function slideUnit(visibleSlides = 1) {
   return 100 / visibleSlides;
 }
 
-export function slideSize(totalSlides, visibleSlides) {
-  return ((100 / totalSlides) * visibleSlides) / visibleSlides;
+export function slideSize(totalSlides, visibleSlides, infinite) {
+  const additionalSlides = infinite ? 2 : 0;
+  return ((100 / (totalSlides + additionalSlides)) * visibleSlides) / visibleSlides;
 }
 
-export function slideTraySize(totalSlides, visibleSlides) {
-  return (100 * totalSlides) / visibleSlides;
+export function slideTraySize(totalSlides, visibleSlides, infinite) {
+  const additionalSlides = infinite ? 2 : 0;
+  return (100 * (totalSlides + additionalSlides)) / visibleSlides;
 }
 
 export function pct(num) {


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Implement infinite functionality so slides scroll continuously without resetting back to the start.

**Why**:

This feature is necessary in any carousel library and is definitely missing from this one.

**How**:

The first and last slides are duplicated to before and after the children (only one slide on either side is additional) making the total slides increase to `totalSlides + 2` if infinite is true.

When `fakeOnDragStart` is executed, the current slide is recomputed and updated if the current slide is one of the outer new infinite slides.

When playForward and playBackward are executed, the current slide is updated with the logic explained in `fakeOnDragStart`.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated
- [ ] Typescript definitions updated (N/A)
- [ ] Tests added and passing
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->

I did not tackle the tests and documentation changes required in this MR. I am posting it here as a headstart for anyone who wants to finish it off.
I will be using the changes in my personal project and felt I should make my implementation public for people to use.

Apologies for submitting an incomplete PR. The infinite functionality is working, it just needs additional testing, documentation updates, etc which I unfortunately don't have time for.
