### PR TITLE
feat: Add ability for buttons to have specific tag/component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>Pure React Carousel</h1>
-  
+
   Created By
   <br />
   <a href="http://www.express.com">
@@ -13,8 +13,8 @@
   </a>
   <br />
   <p>A highly impartial suite of React components that can be assembled by the consumer to create a responsive and aria compliant carousel with almost no limits on DOM structure or CSS styles.</p>
-  
-  [**See Live Examples**](https://express-labs.github.io/pure-react-carousel/) | 
+
+  [**See Live Examples**](https://express-labs.github.io/pure-react-carousel/) |
   [See Example Code](src/App/examples)
 </div>
 
@@ -213,7 +213,7 @@ Any remaining props not consumed by the component are passed directly to the roo
 | dragEnabled | boolean | true | No | Set to true to enable mouse dragging events |
 | visibleSlides | number | 1 | No | The number of slides to show at once.  This number should be <= totalSlides |
 | infinite | boolean | false | No | Should the carousel continue or stop at the beginning or end of the slides |
-| isIntrinsicHeight | boolean | false | No | Disables the enforced height ratio, and instead uses the intrinsic height of the slides. This option can only be active in horizontal orientation, it will throw an error in vertical orientation. | 
+| isIntrinsicHeight | boolean | false | No | Disables the enforced height ratio, and instead uses the intrinsic height of the slides. This option can only be active in horizontal orientation, it will throw an error in vertical orientation. |
 
 #### The CarouselProvider component creates the following pseudo HTML by default:
 
@@ -300,7 +300,7 @@ A Dot component is a HTML button.  Dots directly correlate to slides.  Clicking 
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means Dot will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 | **slide** | number | | **Yes** | There must be a matching &lt;Slide /> component with a matching index property. Example: `<Dot slide={0} />` will match `<Slide index={0} />`|
 
 #### The Dot component creates the following pseudo HTML by default:
@@ -322,7 +322,7 @@ A compound component that creates a bunch of Dot's automatically for you.
 | disableActiveDots | boolean | true | No | Setting to true make all dots, including active dots, enabled. |
 | showAsSelectedForCurrentSlideOnly | boolean | false | No | Setting to true show only the current slide dot as selected. |
 | renderDots | function| null | No | It accepts `props` and overrides renderDots() in <DotGroup/>. |
-| dotTag | [string&#124;function] | undefined | No | Optional tag to use for all dots. It can be either an HTML tag or a React component. It won't have any effect if `renderDots` is provided. |
+| dotTag | [string&#124;function] | undefined | No | Optional tag to use for all dots. It can be either an HTML tag or a React component. It won't have any effect if `renderDots` is provided. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The DotGroup component creates the following pseudo HTML by default:
 
@@ -361,7 +361,7 @@ A button for moving the slider backwards. Backwards on a horizontal carousel mea
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonBack will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The ButtonBack component creates the following pseudo HTML by default:
 
@@ -380,7 +380,7 @@ A button for moving the slider forwards. Forwards on a horizontal carousel means
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonNext will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The ButtonNext component creates the following pseudo HTML by default:
 
@@ -399,7 +399,7 @@ Moves the slider to the beginning of the slides.
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonFirst will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The ButtonFirst component creates the following pseudo HTML by default:
 
@@ -418,7 +418,7 @@ Moves the slider to the end of the slides (totalSlides - visibleSlides).
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonLast will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The ButtonLast component creates the following pseudo HTML by default:
 
@@ -439,7 +439,7 @@ Pressing this button causes the slides to automatically advance by CarouselProvi
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonPlay will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
-| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. **WARNING**: Failure to use a button or an interactive DOM element with the appropriate props can result in failed a11y/w3c compliance. |
 
 #### The ButtonPlay component creates the following pseudo HTML by default:
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ A Dot component is a HTML button.  Dots directly correlate to slides.  Clicking 
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means Dot will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 | **slide** | number | | **Yes** | There must be a matching &lt;Slide /> component with a matching index property. Example: `<Dot slide={0} />` will match `<Slide index={0} />`|
 
 #### The Dot component creates the following pseudo HTML by default:
@@ -321,6 +322,7 @@ A compound component that creates a bunch of Dot's automatically for you.
 | disableActiveDots | boolean | true | No | Setting to true make all dots, including active dots, enabled. |
 | showAsSelectedForCurrentSlideOnly | boolean | false | No | Setting to true show only the current slide dot as selected. |
 | renderDots | function| null | No | It accepts `props` and overrides renderDots() in <DotGroup/>. |
+| dotTag | [string&#124;function] | undefined | No | Optional tag to use for all dots. It can be either an HTML tag or a React component. It won't have any effect if `renderDots` is provided. |
 
 #### The DotGroup component creates the following pseudo HTML by default:
 
@@ -359,6 +361,7 @@ A button for moving the slider backwards. Backwards on a horizontal carousel mea
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonBack will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 
 #### The ButtonBack component creates the following pseudo HTML by default:
 
@@ -377,6 +380,7 @@ A button for moving the slider forwards. Forwards on a horizontal carousel means
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonNext will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 
 #### The ButtonNext component creates the following pseudo HTML by default:
 
@@ -395,6 +399,7 @@ Moves the slider to the beginning of the slides.
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonFirst will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 
 #### The ButtonFirst component creates the following pseudo HTML by default:
 
@@ -413,6 +418,7 @@ Moves the slider to the end of the slides (totalSlides - visibleSlides).
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonLast will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 
 #### The ButtonLast component creates the following pseudo HTML by default:
 
@@ -433,6 +439,7 @@ Pressing this button causes the slides to automatically advance by CarouselProvi
 | className | [string&#124;null] | null | No | Optional className string that will be appended to the component's className string. |
 | disabled | [boolean&#124;null] | null | No | Null means ButtonPlay will automatically determine if this button is disabled. Setting this to true will force the button to be disabled.  Setting this to false will prevent the button from ever being disabled. |
 | onClick | [function&#124;null] | null | No | Optional callback function that is called after the internal onClick function is called. It is passed the React synthetic event |
+| tag | [string&#124;function] | "button" | No | Optional tag to use instead of the default "button". It can be either an HTML tag or a React component. |
 
 #### The ButtonPlay component creates the following pseudo HTML by default:
 
@@ -674,7 +681,7 @@ I promise to add docs for every component.  In the meantime, feel free to downlo
 - `npm start` starts a local development server, opens the dev page with your default browser, and watches for changes via livereload<br><br>
 - `npm run build` compiles commonjs and ES modules and places them in the dist directory<br><br>
 - `npm test` runs unit and integration tests using Jest + Enzyme.  Also does coverage reporting.<br><br>
-- `npm lint` runs linting tests using eslint & airbnb linting.<br><br>
+- `npm run lint` runs linting tests using eslint & airbnb linting.<br><br>
 - `npm test:watch` same as `npm test` but it will watch for updates and auto-run tests. Does not do coverage reporting.<br><br>
 
 ## Contributors

--- a/src/ButtonBack/ButtonBack.jsx
+++ b/src/ButtonBack/ButtonBack.jsx
@@ -15,6 +15,7 @@ export default class ButtonBack extends React.Component {
     totalSlides: PropTypes.number.isRequired,
     visibleSlides: PropTypes.number.isRequired,
     infinite: PropTypes.bool,
+    tag: PropTypes.elementType,
   };
 
   static defaultProps = {
@@ -22,6 +23,7 @@ export default class ButtonBack extends React.Component {
     disabled: null,
     onClick: null,
     infinite: false,
+    tag: 'button',
   };
 
   static setDisabled(disabled, currentSlide, infinite) {
@@ -72,6 +74,7 @@ export default class ButtonBack extends React.Component {
       totalSlides,
       visibleSlides,
       infinite,
+      tag: Tag,
       ...props
     } = this.props;
 
@@ -83,7 +86,7 @@ export default class ButtonBack extends React.Component {
     );
 
     return (
-      <button
+      <Tag
         type="button"
         aria-label="previous"
         className={newClassName}
@@ -92,7 +95,7 @@ export default class ButtonBack extends React.Component {
         {...props}
       >
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 }

--- a/src/ButtonBack/__tests__/ButtonBack.test.jsx
+++ b/src/ButtonBack/__tests__/ButtonBack.test.jsx
@@ -207,4 +207,20 @@ describe('<ButtonBack />', () => {
     wrapper.find('button').simulate('click');
     expect(wrapper.instance().getStore().state.isPlaying).toBe(false);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(
+      <ButtonBack
+        currentSlide={1}
+        step={1}
+        carouselStore={{}}
+        totalSlides={10}
+        visibleSlides={1}
+        tag={CustomButton}
+      >
+      Hello
+      </ButtonBack>,
+    );
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/ButtonBack/__tests__/ButtonBack.test.jsx
+++ b/src/ButtonBack/__tests__/ButtonBack.test.jsx
@@ -223,4 +223,19 @@ describe('<ButtonBack />', () => {
     );
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(
+      <ButtonBack
+        currentSlide={1}
+        step={1}
+        carouselStore={{}}
+        totalSlides={10}
+        visibleSlides={1}
+        tag="a"
+      >
+        Hello
+      </ButtonBack>,
+    );
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/ButtonFirst/ButtonFirst.jsx
+++ b/src/ButtonFirst/ButtonFirst.jsx
@@ -12,12 +12,14 @@ const ButtonFirst = class ButtonFirst extends React.Component {
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
     totalSlides: PropTypes.number.isRequired,
+    tag: PropTypes.elementType,
   }
 
   static defaultProps = {
     className: null,
     disabled: null,
     onClick: null,
+    tag: 'button',
   }
 
   constructor() {
@@ -41,6 +43,7 @@ const ButtonFirst = class ButtonFirst extends React.Component {
       disabled,
       onClick,
       totalSlides,
+      tag: Tag,
       ...props
     } = this.props;
 
@@ -53,7 +56,7 @@ const ButtonFirst = class ButtonFirst extends React.Component {
     const newDisabled = disabled !== null ? disabled : currentSlide === 0;
 
     return (
-      <button
+      <Tag
         type="button"
         aria-label="first"
         className={newClassName}
@@ -62,7 +65,7 @@ const ButtonFirst = class ButtonFirst extends React.Component {
         {...props}
       >
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 };

--- a/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
+++ b/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
@@ -50,4 +50,8 @@ describe('<ButtonFirst />', () => {
     const wrapper = shallow(<ButtonFirst {...props} tag={CustomButton} />);
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(<ButtonFirst {...props} tag="a" />);
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
+++ b/src/ButtonFirst/__tests__/ButtonFirst.test.jsx
@@ -45,4 +45,9 @@ describe('<ButtonFirst />', () => {
     wrapper.find('button').simulate('click');
     expect(props.carouselStore.getStoreState().isPlaying).toBe(false);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<ButtonFirst {...props} tag={CustomButton} />);
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/ButtonLast/ButtonLast.jsx
+++ b/src/ButtonLast/ButtonLast.jsx
@@ -13,12 +13,14 @@ const ButtonLast = class ButtonLast extends React.Component {
     onClick: PropTypes.func,
     totalSlides: PropTypes.number.isRequired,
     visibleSlides: PropTypes.number.isRequired,
+    tag: PropTypes.elementType,
   };
 
   static defaultProps = {
     className: null,
     disabled: null,
     onClick: null,
+    tag: 'button',
   };
 
   constructor() {
@@ -48,6 +50,7 @@ const ButtonLast = class ButtonLast extends React.Component {
       onClick,
       totalSlides,
       visibleSlides,
+      tag: Tag,
       ...props
     } = this.props;
 
@@ -56,7 +59,7 @@ const ButtonLast = class ButtonLast extends React.Component {
     const isDisabled = disabled !== null ? disabled : currentSlide >= totalSlides - visibleSlides;
 
     return (
-      <button
+      <Tag
         type="button"
         aria-label="last"
         className={newClassName}
@@ -65,7 +68,7 @@ const ButtonLast = class ButtonLast extends React.Component {
         {...props}
       >
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 };

--- a/src/ButtonLast/__tests__/ButtonLast.test.jsx
+++ b/src/ButtonLast/__tests__/ButtonLast.test.jsx
@@ -85,4 +85,8 @@ describe('<ButtonLast />', () => {
     const wrapper = shallow(<ButtonLast {...props} tag={CustomButton} />);
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(<ButtonLast {...props} tag="a" />);
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/ButtonLast/__tests__/ButtonLast.test.jsx
+++ b/src/ButtonLast/__tests__/ButtonLast.test.jsx
@@ -80,4 +80,9 @@ describe('<ButtonLast />', () => {
     wrapper.find('button').simulate('click');
     expect(newProps.carouselStore.getStoreState().isPlaying).toBe(false);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<ButtonLast {...props} tag={CustomButton} />);
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/ButtonNext/ButtonNext.jsx
+++ b/src/ButtonNext/ButtonNext.jsx
@@ -15,6 +15,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
     totalSlides: PropTypes.number.isRequired,
     visibleSlides: PropTypes.number.isRequired,
     infinite: PropTypes.bool,
+    tag: PropTypes.elementType,
   };
 
   static defaultProps = {
@@ -22,6 +23,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
     disabled: null,
     onClick: null,
     infinite: false,
+    tag: 'button',
   };
 
   static setDisabled(disabled, currentSlide, visibleSlides, totalSlides, infinite) {
@@ -73,6 +75,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
       totalSlides,
       visibleSlides,
       infinite,
+      tag: Tag,
       ...props
     } = this.props;
 
@@ -86,7 +89,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
     );
 
     return (
-      <button
+      <Tag
         type="button"
         aria-label="next"
         className={newClassName}
@@ -95,7 +98,7 @@ const ButtonNext = class ButtonNext extends React.PureComponent {
         {...props}
       >
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 };

--- a/src/ButtonNext/__tests__/ButtonNext.test.jsx
+++ b/src/ButtonNext/__tests__/ButtonNext.test.jsx
@@ -172,4 +172,8 @@ describe('<ButtonNext />', () => {
     const wrapper = shallow(<ButtonNext {...props} tag={CustomButton} />);
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(<ButtonNext {...props} tag="a" />);
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/ButtonNext/__tests__/ButtonNext.test.jsx
+++ b/src/ButtonNext/__tests__/ButtonNext.test.jsx
@@ -167,4 +167,9 @@ describe('<ButtonNext />', () => {
     wrapper.find('button').simulate('click');
     expect(wrapper.instance().getStore().state.isPlaying).toBe(false);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<ButtonNext {...props} tag={CustomButton} />);
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/ButtonPlay/ButtonPlay.jsx
+++ b/src/ButtonPlay/ButtonPlay.jsx
@@ -12,6 +12,7 @@ const ButtonPlay = class ButtonPlay extends React.PureComponent {
     className: PropTypes.string,
     isPlaying: PropTypes.bool.isRequired,
     onClick: PropTypes.func,
+    tag: PropTypes.elementType,
   };
 
   static defaultProps = {
@@ -20,6 +21,7 @@ const ButtonPlay = class ButtonPlay extends React.PureComponent {
     childrenPlaying: null,
     className: null,
     onClick: null,
+    tag: 'button',
   }
 
   constructor(props) {
@@ -43,6 +45,7 @@ const ButtonPlay = class ButtonPlay extends React.PureComponent {
       className,
       isPlaying,
       onClick,
+      tag: Tag,
       ...props
     } = this.props;
 
@@ -53,7 +56,7 @@ const ButtonPlay = class ButtonPlay extends React.PureComponent {
     ]);
 
     return (
-      <button
+      <Tag
         type="button"
         aria-label="play"
         className={newClassName}
@@ -63,7 +66,7 @@ const ButtonPlay = class ButtonPlay extends React.PureComponent {
         {isPlaying && childrenPlaying}
         {!isPlaying && childrenPaused}
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 };

--- a/src/ButtonPlay/__tests__/ButtonPlay.test.jsx
+++ b/src/ButtonPlay/__tests__/ButtonPlay.test.jsx
@@ -32,4 +32,9 @@ describe('<ButtonPlay />', () => {
     wrapper.find('button').simulate('click');
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<ButtonPlay {...props} tag={CustomButton} />);
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/ButtonPlay/__tests__/ButtonPlay.test.jsx
+++ b/src/ButtonPlay/__tests__/ButtonPlay.test.jsx
@@ -37,4 +37,8 @@ describe('<ButtonPlay />', () => {
     const wrapper = shallow(<ButtonPlay {...props} tag={CustomButton} />);
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(<ButtonPlay {...props} tag="a" />);
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/Dot/Dot.jsx
+++ b/src/Dot/Dot.jsx
@@ -15,6 +15,7 @@ const Dot = class Dot extends React.Component {
     slide: PropTypes.number.isRequired,
     totalSlides: PropTypes.number.isRequired,
     visibleSlides: PropTypes.number.isRequired,
+    tag: PropTypes.elementType,
   }
 
   static defaultProps = {
@@ -23,6 +24,7 @@ const Dot = class Dot extends React.Component {
     disabled: null,
     onClick: null,
     selected: null,
+    tag: 'button',
   }
 
   constructor(props) {
@@ -45,7 +47,7 @@ const Dot = class Dot extends React.Component {
   render() {
     const {
       carouselStore, children, className, currentSlide, disabled, onClick, selected, slide,
-      totalSlides, visibleSlides, ...props
+      totalSlides, visibleSlides, tag: Tag, ...props
     } = this.props;
     const defaultSelected = slide >= currentSlide && slide < (currentSlide + visibleSlides);
     const newSelected = typeof selected === 'boolean' ? selected : defaultSelected;
@@ -62,7 +64,7 @@ const Dot = class Dot extends React.Component {
     ]);
 
     return (
-      <button
+      <Tag
         aria-label="slide dot"
         type="button"
         onClick={this.handleOnClick}
@@ -71,7 +73,7 @@ const Dot = class Dot extends React.Component {
         {...props}
       >
         {this.props.children}
-      </button>
+      </Tag>
     );
   }
 };

--- a/src/Dot/__tests__/Dot.test.jsx
+++ b/src/Dot/__tests__/Dot.test.jsx
@@ -64,4 +64,9 @@ describe('<Dot />', () => {
     wrapper.find('button').simulate('click');
     expect(props.carouselStore.getStoreState().isPlaying).toBe(false);
   });
+  it('should use given tag instead of button', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<Dot {...props} tag={CustomButton} />);
+    expect(wrapper.find(CustomButton)).toBeTruthy();
+  });
 });

--- a/src/Dot/__tests__/Dot.test.jsx
+++ b/src/Dot/__tests__/Dot.test.jsx
@@ -69,4 +69,8 @@ describe('<Dot />', () => {
     const wrapper = shallow(<Dot {...props} tag={CustomButton} />);
     expect(wrapper.find(CustomButton)).toBeTruthy();
   });
+  it('should use given intrinsic tag instead of button', () => {
+    const wrapper = shallow(<Dot {...props} tag="a" />);
+    expect(wrapper.find('a')).toBeTruthy();
+  });
 });

--- a/src/DotGroup/DotGroup.jsx
+++ b/src/DotGroup/DotGroup.jsx
@@ -16,6 +16,7 @@ const DotGroup = class DotGroup extends React.Component {
     disableActiveDots: PropTypes.bool,
     showAsSelectedForCurrentSlideOnly: PropTypes.bool,
     renderDots: PropTypes.func,
+    dotTag: PropTypes.elementType,
   }
 
   static defaultProps = {
@@ -25,6 +26,7 @@ const DotGroup = class DotGroup extends React.Component {
     disableActiveDots: true,
     showAsSelectedForCurrentSlideOnly: false,
     renderDots: null,
+    dotTag: undefined,
   }
 
   renderDots() {
@@ -35,6 +37,7 @@ const DotGroup = class DotGroup extends React.Component {
       disableActiveDots,
       showAsSelectedForCurrentSlideOnly,
       renderDots,
+      dotTag,
     } = this.props;
 
     if (renderDots) {
@@ -54,6 +57,7 @@ const DotGroup = class DotGroup extends React.Component {
           slide={slide}
           selected={selected}
           disabled={disableActiveDots ? selected : false}
+          tag={dotTag}
         >
           <span className={cn['carousel__dot-group-dot']}>{this.props.dotNumbers && i + 1}</span>
         </Dot>,
@@ -74,6 +78,7 @@ const DotGroup = class DotGroup extends React.Component {
       disableActiveDots,
       showAsSelectedForCurrentSlideOnly,
       renderDots,
+      dotTag,
       ...props
     } = this.props;
 

--- a/src/DotGroup/__tests__/DotGroup.test.jsx
+++ b/src/DotGroup/__tests__/DotGroup.test.jsx
@@ -72,4 +72,11 @@ describe('<DotGroup />', () => {
     expect(wrapper.find('img').at(1).text()).toEqual('');
     expect(wrapper.find('img').at(2).text()).toEqual('');
   });
+  it('should forward given tag to the dots', () => {
+    const CustomButton = customProps => (<button type="button" {...customProps} />);
+    const wrapper = shallow(<DotGroup {...props} dotTag={CustomButton} />);
+    expect(wrapper.children().at(0).prop('tag')).toBe(CustomButton);
+    expect(wrapper.children().at(1).prop('tag')).toBe(CustomButton);
+    expect(wrapper.children().at(2).prop('tag')).toBe(CustomButton);
+  });
 });

--- a/src/DotGroup/__tests__/DotGroup.test.jsx
+++ b/src/DotGroup/__tests__/DotGroup.test.jsx
@@ -79,4 +79,10 @@ describe('<DotGroup />', () => {
     expect(wrapper.children().at(1).prop('tag')).toBe(CustomButton);
     expect(wrapper.children().at(2).prop('tag')).toBe(CustomButton);
   });
+  it('should forward given intrinsic tag to the dots', () => {
+    const wrapper = shallow(<DotGroup {...props} dotTag="a" />);
+    expect(wrapper.children().at(0).prop('tag')).toBe('a');
+    expect(wrapper.children().at(1).prop('tag')).toBe('a');
+    expect(wrapper.children().at(2).prop('tag')).toBe('a');
+  });
 });

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -104,6 +104,7 @@ interface DotGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly disableActiveDots?: boolean,
   readonly showAsSelectedForCurrentSlideOnly?: boolean,
   readonly renderDots?: RenderDotsFunction,
+  readonly dotTag?: React.ReactElement,
 }
 type DotGroupInterface = React.ComponentClass<DotGroupProps>
 /**
@@ -119,6 +120,7 @@ interface DotProps extends React.HTMLAttributes<HTMLDivElement> {
   readonly disabled?: boolean
   readonly onClick?: () => void
   readonly slide: number
+  readonly tag?: React.ReactElement
 }
 type DotInterface = React.ComponentClass<DotProps>
 /**
@@ -133,6 +135,7 @@ interface ButtonNextProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly tag?: React.ReactElement
 }
 type ButtonNextInterface = React.ComponentClass<ButtonNextProps>
 /**
@@ -147,6 +150,7 @@ interface ButtonBackProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly tag?: React.ReactElement
 }
 type ButtonBackInterface = React.ComponentClass<ButtonBackProps>
 /**
@@ -161,6 +165,7 @@ interface ButtonLastProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly tag?: React.ReactElement
 }
 type ButtonLastInterface = React.ComponentClass<ButtonLastProps>
 /**
@@ -175,6 +180,7 @@ interface ButtonFirstProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly tag?: React.ReactElement
 }
 type ButtonFirstInterface = React.ComponentClass<ButtonFirstProps>
 /**
@@ -190,6 +196,7 @@ interface ButtonPlayProps extends React.HTMLAttributes<HTMLButtonElement> {
   readonly className?: string
   readonly disabled?: boolean
   readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly tag?: React.ReactElement
 }
 type ButtonPlayInterface = React.ComponentClass<ButtonPlayProps>
 /**


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

The buttons, as well as the dots, can now receive a `tag` prop to allow to use custom element, either native tags, as well as React components. The dotGroup component also handles a `dotTag` prop, that is forwarded to all the dots, if not manually rendered.

**Why**:

This allows developers to use existing components (for both functional and style purposes) instead of relying on pure HTML classes for style.

**How**:

The `tag` prop was added on the following components: `<ButtonBack />`, `<ButtonFirst />`, `<ButtonLast />`, `<ButtonNext />`, `<ButtonPlay />`, and `<Dot />`.
The `dotTag` was added to the `<DotGroup />` component, which forwards the value as the `tag` prop to every `<Dot />`, if not manually rendered.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged

This feature does not contain any breaking change and could be part of a minor release IMO.
