### PR TITLE
Fix issue #343

### DIFF
--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -129,7 +129,6 @@ const Slide = class Slide extends React.PureComponent {
       } else {
         tempStyle.width = 'unset';
       }
-      tempStyle.position = 'unset';
       tempStyle.paddingBottom = 'unset';
       innerStyle.position = 'unset';
     }

--- a/src/Slide/__tests__/Slide.test.jsx
+++ b/src/Slide/__tests__/Slide.test.jsx
@@ -137,7 +137,6 @@ describe('<Slide />', () => {
     const slideStyle = wrapper.find('.slide').prop('style');
     expect(slideStyle.paddingBottom).toBe('unset');
     expect(slideStyle.height).toBe('unset');
-    expect(slideStyle.position).toBe('unset');
 
     const innerSlideStyle = wrapper.find('.carousel__inner-slide').prop('style');
     expect(innerSlideStyle.position).toBe('unset');
@@ -149,7 +148,6 @@ describe('<Slide />', () => {
     const slideStyle = wrapper.find('.slide').prop('style');
     expect(slideStyle.paddingBottom).toBe('unset');
     expect(slideStyle.width).toBe('unset');
-    expect(slideStyle.position).toBe('unset');
 
     const innerSlideStyle = wrapper.find('.carousel__inner-slide').prop('style');
     expect(innerSlideStyle.position).toBe('unset');


### PR DESCRIPTION
Slide set with unset position was causing the focus ring to expand past the parent

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: Slide set with unset position and when using isIntrinsicHeight was causing the focus ring to expand past the parent. See Issue #343 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:  When focused the slide position's CSS of relative was being overwritten to unset causing the focus ring to assume the width of the entire slider which is 200%.

<!-- Why are these changes necessary? -->

**How**:  Removing the position unset keeps the focus ring set to the width of the slide.

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated (N/A)
- [ ] Typescript definitions updated (N/A)
- [ x ] Tests added and passing (N/A)
- [ x ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
