### PR TITLE
Update types and documentation regarding isIntrinsicHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Any remaining props not consumed by the component are passed directly to the roo
 | interval | number | 5000 | No | Number of milliseconds to wait when the auto slideshow is active |
 | isPlaying | bool | false | No | Setting this to true starts an auto slideshow. After "interval" milliseconds, the slider will move by "step" slides either forward or backwards depending on the value of "playDirection". |
 | lockOnWindowScroll | bool | false | No | When set to true, scrolling of the carousel slides are disabled while the browser window is scrolling |
-| **naturalSlideHeight** | number | | **Yes** | The natural height of each <\Slide > component. ** |
-| **naturalSlideWidth** | number | | **Yes** | The natural width of each <\Slide > component. ** |
+| **naturalSlideHeight** | number | | **Yes** / <abbr title="Not required when isIntrinsicHeight is true">No</abbr> | The natural height of each <\Slide > component. |
+| **naturalSlideWidth** | number | | **Yes** / <abbr title="Not required when isIntrinsicHeight is true">No</abbr> | The natural width of each <\Slide > component. |
 | orientation | string | "horizontal" | No | Possible values are "horizontal" and "vertical".  Let's you have a horizontal or vertical carousel. |
 | playDirection | ['forward'&#124;'backward' ] | 'forward' | No | The direction for the auto slideshow |
 | step | number | 1 | No | The number of slides to move when pressing the &lt;ButtonBack /> and &lt;ButtonNext /> buttons.|
@@ -224,7 +224,9 @@ Any remaining props not consumed by the component are passed directly to the roo
 ```
 
 **__More about naturalSlideWidth and naturalSlideHeight__**
-The carousel is responsive and by default will flex to the full width of the <Slider \> parent container.  It's up to you to contain the carousel width via css.  Each slide will be the same height to width ratio ([intrinsic ratio](https://alistapart.com/d/creating-intrinsic-ratios-for-video/example2.html)). CarouselProvider needs to know the default size of each &lt;Slide />.  Note: you can make the carousel non-responsive by setting the width of <Slider \>to a fixed css unit, like pixels. There are many other ways to make the carousel non-responsive.
+The carousel is responsive and by default will flex to the full width of the <Slider \> parent container.  It's up to you to contain the carousel width via css.  Each slide will be the same height to width ratio ([intrinsic ratio](https://alistapart.com/d/creating-intrinsic-ratios-for-video/example2.html)). However if `isIntrinsicHeight` is set to `true` each slide will have natural height based on its content. 
+
+Note: you can make the carousel non-responsive by setting the width of <Slider \>to a fixed css unit, like pixels. There are many other ways to make the carousel non-responsive.
 
 ### &lt;Slider />
 A Slider is a viewport that masks slides.  The Slider component must wrap one or more Slide components.

--- a/src/App/examples/Example13/Example13.jsx
+++ b/src/App/examples/Example13/Example13.jsx
@@ -10,8 +10,6 @@ export default () => (
     visibleSlides={2}
     totalSlides={4}
     step={1}
-    naturalSlideWidth={400}
-    naturalSlideHeight={500}
     isIntrinsicHeight
   >
     <h2 className={s.headline}>With intrinsic axis dimension</h2>

--- a/src/CarouselProvider/CarouselProvider.jsx
+++ b/src/CarouselProvider/CarouselProvider.jsx
@@ -18,8 +18,10 @@ const CarouselProvider = class CarouselProvider extends React.Component {
     isPageScrollLocked: PropTypes.bool,
     isPlaying: PropTypes.bool,
     lockOnWindowScroll: PropTypes.bool,
-    naturalSlideHeight: PropTypes.number.isRequired,
-    naturalSlideWidth: PropTypes.number.isRequired,
+    /* eslint-disable react/require-default-props */
+    naturalSlideHeight: CarouselPropTypes.slideSize,
+    naturalSlideWidth: CarouselPropTypes.slideSize,
+    /* eslint-enable react/require-default-props */
     orientation: CarouselPropTypes.orientation,
     playDirection: CarouselPropTypes.direction,
     step: PropTypes.number,

--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -15,8 +15,10 @@ const Slide = class Slide extends React.PureComponent {
     index: PropTypes.number.isRequired,
     innerClassName: PropTypes.string,
     innerTag: PropTypes.string,
-    naturalSlideHeight: PropTypes.number.isRequired,
-    naturalSlideWidth: PropTypes.number.isRequired,
+    /* eslint-disable react/require-default-props */
+    naturalSlideHeight: CarouselPropTypes.slideSize,
+    naturalSlideWidth: CarouselPropTypes.slideSize,
+    /* eslint-enable react/require-default-props */
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     orientation: CarouselPropTypes.orientation.isRequired,

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -29,8 +29,10 @@ const Slider = class Slider extends React.Component {
     lockOnWindowScroll: PropTypes.bool.isRequired,
     masterSpinnerFinished: PropTypes.bool.isRequired,
     moveThreshold: PropTypes.number,
-    naturalSlideHeight: PropTypes.number.isRequired,
-    naturalSlideWidth: PropTypes.number.isRequired,
+    /* eslint-disable react/require-default-props */
+    naturalSlideHeight: CarouselPropTypes.slideSize,
+    naturalSlideWidth: CarouselPropTypes.slideSize,
+    /* eslint-enable react/require-default-props */
     onMasterSpinner: PropTypes.func,
     orientation: CarouselPropTypes.orientation.isRequired,
     playDirection: CarouselPropTypes.direction.isRequired,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -38,13 +38,6 @@ export const CarouselPropTypes = {
     PropTypes.node,
   ]),
   direction: PropTypes.oneOf(['forward', 'backward']),
-  height: (props, propName) => {
-    const prop = props[propName];
-    if (props.orientation === 'vertical' && (prop === null || typeof prop !== 'number')) {
-      return new Error(`Missing required property '${propName}' when orientation is vertical.  You must supply a number representing the height in pixels`);
-    }
-    return null;
-  },
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   isBgImage: (props, propName) => {
     const value = props[propName];
@@ -52,6 +45,12 @@ export const CarouselPropTypes = {
       return new Error(`HTML img elements should not have a backgroundImage.  Please use ${propName} for other block-level HTML tags, like div, a, section, etc...`);
     }
     return null;
+  },
+  slideSize: (props, propName, componentName, ...rest) => {
+    if (props.isIntrinsicHeight === true) {
+      return PropTypes.number(props, propName, componentName, ...rest);
+    }
+    return PropTypes.number.isRequired(props, propName, componentName, ...rest);
   },
 };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -71,7 +71,7 @@ interface CarouselStoreInterface {
 
 declare const CarouselContext: React.Context<CarouselStoreInterface>
 
-type CarouselProviderProps = {
+type CarouselProviderBaseProps = {
   readonly children: React.ReactNode
   readonly className?: string
   readonly currentSlide?: CarouselState['currentSlide']
@@ -91,24 +91,31 @@ type CarouselProviderProps = {
   readonly dragEnabled?: CarouselState['dragEnabled']
   readonly visibleSlides?: CarouselState['visibleSlides']
   readonly infinite?: CarouselState['infinite']
-} & {
   readonly isIntrinsicHeight?: CarouselState['isIntrinsicHeight']
+}
+
+type RequiredSlideSizes = {
   readonly naturalSlideHeight: CarouselState['naturalSlideHeight']
   readonly naturalSlideWidth: CarouselState['naturalSlideWidth']
-} | {
+}
+
+type RequiredIntrinsicHeight = {
   readonly isIntrinsicHeight: true
   readonly naturalSlideHeight?: CarouselState['naturalSlideHeight']
   readonly naturalSlideWidth?: CarouselState['naturalSlideWidth']
 }
+
+type CarouselProviderProps = CarouselProviderBaseProps & (RequiredSlideSizes | RequiredIntrinsicHeight)
 
 type CarouselProviderInterface = React.ComponentClass<CarouselProviderProps>
 /**
  * CarouselProvider allows the other carousel components to communicate with each other.
  *
  * The only required properties are:
- * the totalSlides, naturalSlideWidth, and naturalSlideHeight.
+ * the `totalSlides`, `naturalSlideWidth`, and `naturalSlideHeight`.
+ * If `isIntrinsicHeight` is `true`, then natural slide sizes are not required.
  *
- * The naturalSlideWidth and naturalSlideHeight are used
+ * The `naturalSlideWidth` and `naturalSlideHeight` are used
  * to create an aspect ratio for each slide.
  *
  * Since the carousel is responsive by default,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -71,7 +71,7 @@ interface CarouselStoreInterface {
 
 declare const CarouselContext: React.Context<CarouselStoreInterface>
 
-interface CarouselProviderProps {
+type CarouselProviderProps = {
   readonly children: React.ReactNode
   readonly className?: string
   readonly currentSlide?: CarouselState['currentSlide']
@@ -81,8 +81,6 @@ interface CarouselProviderProps {
   readonly interval?: number
   readonly isPlaying?: boolean
   readonly lockOnWindowScroll?: CarouselState['lockOnWindowScroll']
-  readonly naturalSlideHeight: CarouselState['naturalSlideHeight']
-  readonly naturalSlideWidth: CarouselState['naturalSlideWidth']
   readonly playDirection?: 'forward'|'backward'
   readonly orientation?: CarouselState['orientation']
   readonly step?: CarouselState['step']
@@ -93,7 +91,14 @@ interface CarouselProviderProps {
   readonly dragEnabled?: CarouselState['dragEnabled']
   readonly visibleSlides?: CarouselState['visibleSlides']
   readonly infinite?: CarouselState['infinite']
+} & {
   readonly isIntrinsicHeight?: CarouselState['isIntrinsicHeight']
+  readonly naturalSlideHeight: CarouselState['naturalSlideHeight']
+  readonly naturalSlideWidth: CarouselState['naturalSlideWidth']
+} | {
+  readonly isIntrinsicHeight: true
+  readonly naturalSlideHeight?: CarouselState['naturalSlideHeight']
+  readonly naturalSlideWidth?: CarouselState['naturalSlideWidth']
 }
 
 type CarouselProviderInterface = React.ComponentClass<CarouselProviderProps>


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:
https://github.com/express-labs/pure-react-carousel/issues/356

Update types to make `naturalSlideWidth` and height optional when `isIntrensicHeight` is true

**Why**:
To avoid confusion and do not force user to set props that are not needed in certain situations.

**How**:
Changes to documentation, TS typings and `PropTypes`

Additionally I've deleted unused custom prop type `height`

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

