### PR TITLE
feat: Add Typings for isPlaying of CarouselState

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,6 +35,7 @@ interface CarouselState {
   readonly hasMasterSpinner: boolean
   readonly imageErrorCount: number
   readonly imageSuccessCount: number
+  readonly isPlaying: boolean
   readonly lockOnWindowScroll: boolean
   readonly masterSpinnerFinished: boolean
   readonly masterSpinnerThreshold: number
@@ -79,7 +80,7 @@ interface CarouselProviderProps {
   readonly disableKeyboard?: CarouselState['disableKeyboard']
   readonly hasMasterSpinner?: CarouselState['hasMasterSpinner']
   readonly interval?: number
-  readonly isPlaying?: boolean
+  readonly isPlaying?: CarouselState['isPlaying']
   readonly lockOnWindowScroll?: CarouselState['lockOnWindowScroll']
   readonly naturalSlideHeight: CarouselState['naturalSlideHeight']
   readonly naturalSlideWidth: CarouselState['naturalSlideWidth']


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Add Typings for isPlaying of CarouselState.

**Why**:

I want to control autoplay by isPlaying of CarouselState, and avoid type errors in this case.

```ts
carouselContext.setStoreState({ isPlaying: true });
```

**How**:

Add definition to typings/index.d.ts.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added/updated (N/A)
- [x] Typescript definitions updated
- [ ] Tests added and passing (N/A)
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
