### PR TITLE
Add image loading error handling capabilities to ImageWithZoom #386

### DIFF
--- a/src/ImageWithZoom/ImageWithZoom.jsx
+++ b/src/ImageWithZoom/ImageWithZoom.jsx
@@ -19,6 +19,8 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
     imageClassName: PropTypes.string,
     overlayClassName: PropTypes.string,
     spinner: PropTypes.func,
+    onLoad: PropTypes.func,
+    onError: PropTypes.func,
     src: PropTypes.string.isRequired,
     srcZoomed: PropTypes.string,
     tag: PropTypes.string,
@@ -34,6 +36,8 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
     overlayClassName: null,
     isPinchZoomEnabled: true,
     spinner: null,
+    onLoad: null,
+    onError: null,
     srcZoomed: null,
     tag: 'div',
   }
@@ -76,8 +80,11 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
 
     // state changes that require a re-render
     this.state = {
-      // tracks the status via image element's onload, onerror events.
+      // tracks the status via image element's onload events.
       isImageLoading: true,
+
+      // tracks the status via image element's onerror events.
+      isImageLoadingError: true,
 
       // the mouse is currently hovering over the image.
       isHovering: false,
@@ -100,6 +107,7 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
 
     // event handlers
     this.handleImageComplete = this.handleImageComplete.bind(this);
+    this.handleImageLoadError = this.handleImageLoadError.bind(this);
     this.handleOnMouseMove = this.handleOnMouseMove.bind(this);
     this.handleOnMouseOut = this.handleOnMouseOut.bind(this);
     this.handleOnMouseOver = this.handleOnMouseOver.bind(this);
@@ -121,10 +129,19 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
     }
   }
 
-  handleImageComplete() {
+  handleImageComplete(ev) {
     this.setState({
       isImageLoading: false,
     });
+    if (this.props.onLoad) this.props.onLoad(ev);
+  }
+
+  handleImageLoadError(ev) {
+    this.setState({
+      isImageLoadingError: true,
+      isImageLoading: false,
+    });
+    if (this.props.onError) this.props.onError(ev);
   }
 
   handleOnMouseOver() {
@@ -324,7 +341,7 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
           tag={bgImageTag}
           src={src}
           onLoad={this.handleImageComplete}
-          onError={this.handleImageComplete}
+          onError={this.handleImageLoadError}
           {...bgImageProps}
         />
         <Image

--- a/src/ImageWithZoom/ImageWithZoom.jsx
+++ b/src/ImageWithZoom/ImageWithZoom.jsx
@@ -133,7 +133,7 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
     this.setState({
       isImageLoading: false,
     });
-    if (this.props.onLoad) this.props.onLoad(ev);
+    if (this.props && this.props.onLoad) this.props.onLoad(ev);
   }
 
   handleImageLoadError(ev) {
@@ -141,7 +141,7 @@ const ImageWithZoom = class ImageWithZoom extends React.Component {
       isImageLoadingError: true,
       isImageLoading: false,
     });
-    if (this.props.onError) this.props.onError(ev);
+    if (this.props && this.props.onError) this.props.onError(ev);
   }
 
   handleOnMouseOver() {

--- a/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
+++ b/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
@@ -90,7 +90,7 @@ describe('<ImageWithZoom />', () => {
         instance.handleImageLoadError();
         expect(instance.setState).toHaveBeenCalledWith({
           isImageLoading: false,
-          isImageLoadingError: true
+          isImageLoadingError: true,
         });
       });
     });

--- a/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
+++ b/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
@@ -75,13 +75,22 @@ describe('<ImageWithZoom />', () => {
         expect(instance.renderLoading()).toBe(null);
       });
     });
-    describe('handleImageComplete', () => {
-      it('should set state isImageLoading', () => {
+    describe('handleImage callback', () => {
+      it('should set state isImageLoading when function handleImageComplete is called', () => {
         const instance = new ImageWithZoom();
         instance.setState = jest.fn();
         instance.handleImageComplete();
         expect(instance.setState).toHaveBeenCalledWith({
           isImageLoading: false,
+        });
+      });
+      it('should set state isImageLoading, isImageLoadingError when function handleImageLoadError is called', () => {
+        const instance = new ImageWithZoom();
+        instance.setState = jest.fn();
+        instance.handleImageLoadError();
+        expect(instance.setState).toHaveBeenCalledWith({
+          isImageLoading: false,
+          isImageLoadingError: true
         });
       });
     });

--- a/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
+++ b/src/ImageWithZoom/__tests__/ImageWithZoom.test.jsx
@@ -93,6 +93,20 @@ describe('<ImageWithZoom />', () => {
           isImageLoadingError: true,
         });
       });
+      it('should call onError prop function when function handleImageLoadError is called', () => {
+        const onError = jest.fn();
+        const instance = new ImageWithZoom({ onError });
+        instance.setState = jest.fn();
+        instance.handleImageLoadError();
+        expect(onError).toHaveBeenCalled();
+      });
+      it('should call onLoad prop function when function handleImageComplete is called', () => {
+        const onLoad = jest.fn();
+        const instance = new ImageWithZoom({ onLoad });
+        instance.setState = jest.fn();
+        instance.handleImageComplete();
+        expect(onLoad).toHaveBeenCalled();
+      });
     });
   });
   describe('integration tests', () => {

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -54,6 +54,8 @@ interface ImageWithZoomProps {
   readonly className?: string
   readonly imageClassName?: string
   readonly overlayClassName?: string
+  readonly onError?: () => void
+  readonly onLoad?: () => void
   readonly src: string
   readonly srcZoomed?: string
   readonly tag?: string


### PR DESCRIPTION

**What**:

We are not getting any callback handler when Image fails to load in ImageWithZoom component. 

**Why**:

This can be handy feature for handling wrong/Invalid  Url when image fails to load.
After that user can use alternate url

**How**:

Added OnLoad OnError props in ImageWithZoom component 

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ N/A] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

