### PR TITLE
docs: readme heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Some components have a ancestor / descendant relationship but they don't have to
 
 ## Component Properties (props)
 
-#### classname
+#### className
 
 You can attach your own className property to each and every component in this library and it will be appended to the list of classes.  It's appended so that it has more specificity in a tie, allowing your CSS to more easily override any internal styles without resorting to using !important.
 

--- a/README.md
+++ b/README.md
@@ -759,3 +759,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+ 

--- a/README.md
+++ b/README.md
@@ -759,4 +759,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
- 


### PR DESCRIPTION
**What**:

- `classname` heading typo change to `className`

**Why**:

- props are using camelcase, I suppose this was overlooked

**How**:

- just a text change

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated 
- [ ] Typescript definitions updated N/A
- [ ] Tests added and passing N/A
- [x] Ready to be merged 

