### PR TITLE
Moved cancelAnimationFrame inside fakeOnDragMove

### DIFF
--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -219,6 +219,8 @@ const Slider = class Slider extends React.Component {
   }
 
   fakeOnDragMove(screenX, screenY) {
+    window.cancelAnimationFrame.call(window, this.moveTimer);
+    
     this.moveTimer = window.requestAnimationFrame.call(window, () => {
       this.setState(state => ({
         deltaX: screenX - state.startX,
@@ -329,8 +331,6 @@ const Slider = class Slider extends React.Component {
       this.callCallback('onTouchMove', ev);
       return;
     }
-
-    window.cancelAnimationFrame.call(window, this.moveTimer);
 
     const touch = ev.targetTouches[0];
     // TODO: This prevents an error case we were seeing internally, but long term we


### PR DESCRIPTION
Hi, 

Bug brought up in #179, issue was identified by [third774](https://github.com/third774)
Fast drag and release would result in the carousel getting "stuck"

**What**:

Queued dragMove updates would occur after dragEnd resulting in the delta states not being zeroed within the Slider component

**Why**:

The changes fix the issue

**How**:

I removed the cancelAnimationFrame from handleOnTouchMove and added it to fakeOnDragMove which is used by both handleOnMouseMove and handleOnTouchMove and the method that requires the cancelling.

**Checklist**:

- [ ] Documentation added/updated (N/A)
- [ ] Typescript definitions updated (N/A)
- [ ] Tests added and passing (N/A)
- [x] Ready to be merged

Thanks
