### PR TITLE
Allow React 18 for peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
     "watch": "^1.0.2"
   },
   "peerDependencies": {
-    "react": "15.x || 16.x || 17.x",
-    "react-dom": "15.x || 16.x || 17.x"
+    "react": "15.x || 16.x || 17.x || 18.x",
+    "react-dom": "15.x || 16.x || 17.x || 18.x"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Previously when running `npm install` you got an error saying that React is only supported up until version 17. You could get arround this by adding the following to project using this package:

```
  "overrides": {
    "react": "^18.1.0",
    "react-dom": "^18.1.0"
  },
```
But this PR is adding React 18.x as well so it's not needed anymore.

React 18 is really not that different from React 17. The project itself is still using React 16.

I tried this with the change, building it to a local package, installing it in another project and it worked just fine.

**Why**:

More projects is using React 18 every day and we don't want them to be forced to override dependencies if possible.

**How**:

Updated the peer dependencies for react and react-dom

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
