### PR TITLE
feat: peer dependency react 18

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -360,6 +360,24 @@
       "contributions": [
         "question"
       ]
+    },
+    {
+      "login": "GLosch",
+      "name": "Gabby Losch",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5502159?v=4",
+      "profile": "https://github.com/GLosch",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "tonygustafsson",
+      "name": "Tony Gustafsson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7383255?v=4",
+      "profile": "https://www.tonyg.se/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,


### PR DESCRIPTION

Semantic release action seems to no longer be working on PR. 

adding contributors to the contributor list and pushing this up to release

https://github.com/express-labs/pure-react-carousel/pull/415