### PR TITLE
feat:preventVerticalScrollOnTouch

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,6 @@ Any remaining props not consumed by the component are passed directly to the roo
 | interval | number | 5000 | No | Number of milliseconds to wait when the auto slideshow is active |
 | isPlaying | bool | false | No | Setting this to true starts an auto slideshow. After "interval" milliseconds, the slider will move by "step" slides either forward or backwards depending on the value of "playDirection". |
 | lockOnWindowScroll | bool | false | No | When set to true, scrolling of the carousel slides are disabled while the browser window is scrolling |
-| preventVerticalScrollOnTouch | bool | true | No | When set to true, prevents vertical screen scroll based on touch move of the carousel|
-| horizontalPixelThreshold| number | 15 | No | The minimum amount of pixels moved horizontally, by touch on the carousel, which will block page scroll if the  movement in pixels is greater or equal than the amount of the provided value.|
-| verticalPixelThreshold | number | 10 | No | The maximum amount of pixels moved vertically, by touch on the carousel, which will block page scroll if the movement in pixels is less than the provided value |
 | **naturalSlideHeight** | number | | **Yes** | The natural height of each <\Slide > component. ** |
 | **naturalSlideWidth** | number | | **Yes** | The natural width of each <\Slide > component. ** |
 | orientation | string | "horizontal" | No | Possible values are "horizontal" and "vertical".  Let's you have a horizontal or vertical carousel. |
@@ -246,6 +243,9 @@ A Slider is a viewport that masks slides.  The Slider component must wrap one or
 | classNameTray | [string&#124;null] | null | No | Optional className string that is applied to the Slider's tray. The "tray" is the DOM element that contains the slides. The type of DOM element is specified by the trayTag property |
 | classNameTrayWrap | [string&#124;null] | null | No | Optional className string that is applied to a div that surrounds the Slider's tray |
 | moveThreshold | number | 0.1 | No | Threshold to control the drag distance that triggers a scroll to the next or previous slide. (slide width or height * moveThreshold = drag pixel distance required to scroll) |
+| preventVerticalScrollOnTouch | bool | true | No | When set to true and touch enabled, prevents vertical screen scroll based on touch move of the carousel|
+| horizontalPixelThreshold| number | 15 | No | The minimum amount of pixels moved horizontally, by touch on the carousel, which will block page scroll if the  movement in pixels is greater or equal than the amount of the provided value.|
+| verticalPixelThreshold | number | 10 | No | The maximum amount of pixels moved vertically, by touch on the carousel, which will block page scroll if the movement in pixels is less than the provided value |
 | onMasterSpinner | [function&#124;null] | null | No | Optional callback function that is called when the Master Spinner is visible.  Requires that &lt;CarouselProvider /> set hasMasterSpinner to true |
 | spinner | function | null | No |  Optional inline JSX (aka "render props") to render your own custom spinner.  Example `() => <MyCustomSpinnerComponent />`.  If left blank, the default spinner is used. |
 | style | object | {} | No | Optional css styles to add to the Slider.  Note: internal css properties take precedence over any styles specified in the styles object |


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: Horizontal touch movements that are not 100% horizontal will scroll the page vertically, which could be frustrating to end users. 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: Feature request to implement a prevention of page scroll based on the delta positions of touch. 

<!-- Why are these changes necessary? -->

**How**: A listener will be added to the window preventing the default behavior of the page, which is to scroll, if the delta positions of said touch movement is mostly horizontal in nature. The default threshold of these values is set to a horizontal delta greater than 15px and the vertical delta being less than 10px. These thresholds can be modified directly by the consumer of the library by changing the initial props and the feature can be opted out directly if so desired.

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added/updated
- [x] Typescript definitions updated
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
