### PR TITLE
fix: typing-for-preventVerticalScroll

### DIFF
--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -654,6 +654,7 @@ const Slider = class Slider extends React.Component {
       step,
       infinite,
       preventVerticalScrollOnTouch,
+      preventingVerticalScroll,
       horizontalPixelThreshold,
       verticalPixelThreshold,
       ...rest

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -86,8 +86,8 @@ interface CarouselProviderProps {
   readonly isPlaying?: CarouselState['isPlaying']
   readonly lockOnWindowScroll?: CarouselState['lockOnWindowScroll']
   readonly preventVerticalScrollOnTouch?: CarouselState['preventVerticalScrollOnTouch']
-  readonly horizontalPixelThreshold: CarouselState['horizontalPixelThreshold']
-  readonly verticalPixelThreshold: CarouselState['verticalPixelThreshold'],
+  readonly horizontalPixelThreshold?: CarouselState['horizontalPixelThreshold']
+  readonly verticalPixelThreshold?: CarouselState['verticalPixelThreshold'],
   readonly naturalSlideHeight: CarouselState['naturalSlideHeight']
   readonly naturalSlideWidth: CarouselState['naturalSlideWidth']
   readonly playDirection?: 'forward' | 'backward'


### PR DESCRIPTION
fix for https://github.com/express-labs/pure-react-carousel/issues/423