### PR TITLE
Do not apply `touch-action` style if `touchEnabled === false`

### DIFF
--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -624,6 +624,7 @@ const Slider = class Slider extends React.Component {
 
     const sliderClasses = cn([
       orientation === 'vertical' ? s.verticalSlider : s.horizontalSlider,
+      !touchEnabled && s.touchDisabled,
       'carousel__slider',
       orientation === 'vertical' ? 'carousel__slider--vertical' : 'carousel__slider--horizontal',
       className,

--- a/src/Slider/Slider.scss
+++ b/src/Slider/Slider.scss
@@ -1,7 +1,9 @@
 .horizontalSlider {
   position: relative;
   overflow: hidden;
-  touch-action: pan-y pinch-zoom;
+  &:not(.touchDisabled) {
+    touch-action: pan-y pinch-zoom;
+  }
 
   [dir='rtl'] & {
     direction: ltr;

--- a/src/Slider/__tests__/Slider.test.jsx
+++ b/src/Slider/__tests__/Slider.test.jsx
@@ -222,12 +222,12 @@ describe('<Slider />', () => {
         expect(global.window.addEventListener).toHaveBeenCalledWith('touchmove', instance.blockWindowScroll, false);
         expect(global.window.addEventListener).toHaveBeenCalledTimes(1);
       });
-      it('should NOT an event listener to Window for blocking vertical scroll on touchmove if the prop preventVerticalScrollOnTouch is false', () => {
+      it('should NOT add an event listener to Window for blocking vertical scroll on touchmove if the prop preventVerticalScrollOnTouch is false', () => {
         const instance = new Slider({ preventVerticalScrollOnTouch: false });
         instance.componentDidMount();
         expect(global.window.addEventListener).toHaveBeenCalledTimes(0);
       });
-      it('should NOT an event listener to Window for blocking vertical scroll on touchmove if the prop touchEnabled is false', () => {
+      it('should NOT add an event listener to Window for blocking vertical scroll on touchmove if the prop touchEnabled is false', () => {
         const instance = new Slider({ touchEnabled: false });
         instance.componentDidMount();
         expect(global.window.addEventListener).toHaveBeenCalledTimes(0);

--- a/src/Slider/__tests__/Slider.test.jsx
+++ b/src/Slider/__tests__/Slider.test.jsx
@@ -627,6 +627,13 @@ describe('<Slider />', () => {
       expect(wrapper.state('deltaY')).toBe(0);
     });
 
+    it('should not set touch-action css property if touchEnabled is false', () => {
+      const wrapper = mount(<Slider {...props} touchEnabled />);
+      expect(wrapper.getDOMNode().classList.contains('touchDisabled')).toBe(false);
+      wrapper.setProps({ touchEnabled: false });
+      expect(wrapper.getDOMNode().classList.contains('touchDisabled')).toBe(true);
+    });
+
     it('touchmove should not alter state if props.lockOnWindowScroll and this.isDocumentScrolling are both true', () => {
       const wrapper = shallow(<Slider {...props} lockOnWindowScroll />);
       const instance = wrapper.instance();


### PR DESCRIPTION
**What**:
I considered using an attribute instead of a class for the conditional logic, but ultimately thought that a class felt more appropriate in this case. I considered inverting the logic so that the `touchEnabled` conditional matched the `touchEnabled` prop, but it felt less good to always add the conditional class in the default case, rather than only adding it if overriding the `touchEnabled` prop. But happy to invert the logic if you prefer.

**Why**:
Fixes #442 

**How**:
Move the offending style into a style block which is excluded if a conditional class is appended.

**Checklist**:
- [ ] Documentation added/updated N/A
- [ ] Typescript definitions updated N/A
- [x] Tests added and passing
- [x] Ready to be merged <!-- In your opinion -->