### PR TITLE
Fix bug on slider when dragging in `rtl` mode

### DIFF
--- a/src/App/examples/Example14/Example14.jsx
+++ b/src/App/examples/Example14/Example14.jsx
@@ -15,21 +15,21 @@ import
 import s from '../../style.scss';
 
 export default () => (
-  <CarouselProvider
-    visibleSlides={2}
-    totalSlides={8}
-    step={1}
-    naturalSlideWidth={400}
-    naturalSlideHeight={500}
-  >
-    <h2 className={s.headline}>RTL</h2>
-    <p>
+  <div dir="rtl">
+    <CarouselProvider
+      visibleSlides={2}
+      totalSlides={8}
+      step={1}
+      naturalSlideWidth={400}
+      naturalSlideHeight={500}
+    >
+      <h2 className={s.headline}>RTL</h2>
+      <p>
       A carousel wrapped in an element with
-      {' '}
-      <code>dir=&quot;rtl&quot;</code>
+        {' '}
+        <code>dir=&quot;rtl&quot;</code>
 , demonstrating support for use with right-to-left languages.
-    </p>
-    <div dir="rtl">
+      </p>
       <Slider className={s.slider}>
         <Slide index={0}>
           <ImageWithZoom src="./media/img01.jpeg" />
@@ -61,6 +61,6 @@ export default () => (
       <ButtonNext>Next</ButtonNext>
       <ButtonLast>Last</ButtonLast>
       <DotGroup dotNumbers />
-    </div>
-  </CarouselProvider>
+    </CarouselProvider>
+  </div>
 );

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -201,6 +201,9 @@ const Slider = class Slider extends React.Component {
 
   getSliderRef(el) {
     this.sliderTrayElement = el;
+    // NOTE: we can't rely on the element itself to detect direction
+    // as the direction of the slider is currently flipped to ltr
+    this.rtl = window.getComputedStyle(el.closest('.carousel'), null).getPropertyValue('direction') === 'rtl';
   }
 
 
@@ -233,7 +236,7 @@ const Slider = class Slider extends React.Component {
   fakeOnDragMove(screenX, screenY) {
     this.moveTimer = window.requestAnimationFrame.call(window, () => {
       this.setState(state => ({
-        deltaX: screenX - state.startX,
+        deltaX: (screenX - state.startX) * (this.rtl ? -1 : 1),
         deltaY: screenY - state.startY,
         preventingVerticalScroll: Math.abs(screenY - state.startY)
           <= this.props.verticalPixelThreshold

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -201,9 +201,14 @@ const Slider = class Slider extends React.Component {
 
   getSliderRef(el) {
     this.sliderTrayElement = el;
-    // NOTE: we can't rely on the element itself to detect direction
-    // as the direction of the slider is currently flipped to ltr
-    this.rtl = window.getComputedStyle(el.closest('.carousel'), null).getPropertyValue('direction') === 'rtl';
+    if (el && window) {
+      // NOTE: we can't rely on the element itself to detect direction
+      // as the direction of the slider is currently flipped to ltr
+      const carouselElement = el.closest('.carousel');
+      if (carouselElement) {
+        this.rtl = window.getComputedStyle(carouselElement, null).getPropertyValue('direction') === 'rtl';
+      }
+    }
   }
 
 


### PR DESCRIPTION
**What**:

Fix bug on slider when dragging in `rtl` mode. If you drag to the left, the slider animates to the right (and vice-versa). This broken behaviour can be observed on the [examples page](https://express-labs.github.io/pure-react-carousel/#example--14).

See also [here](https://github.com/express-labs/pure-react-carousel/issues/97#issuecomment-738698238) and [here](https://github.com/express-labs/pure-react-carousel/issues/419).

**Why**:

Dragging on the carousel is broken for `rtl` pages.

**How**:

Rather than require a prop to be passed into the component, the `Slider` component detects whether the `direction` is `rtl` and inverts `deltaX` during drag accordingly.

**Checklist**:

- [ ] Documentation added/updated (N/A)
- [ ] Typescript definitions updated (N/A)
- [ ] Tests added and passing (Experiment page updated and verified - do we need automated tests for this behaviour?)
- [X] Ready to be merged

